### PR TITLE
Add an explicit sleep to delay retries.

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -49,7 +49,8 @@ slave_poll_count=0
 aws ec2 wait instance-status-ok --instance-ids $SERVER_ID
 while [ ! $slave_ready ] && [ $slave_poll_count -lt 40 ] ; do
     echo "Waiting for slave instance to become ready"
-    ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o BatchMode=yes $USER@$SERVER_IP hostname
+    sleep 5
+    ssh -T -o ConnectTimeout=1 -o StrictHostKeyChecking=no -o BatchMode=yes $USER@$SERVER_IP hostname
     if [ $? -eq 0 ]; then
       slave_ready='1'
     fi


### PR DESCRIPTION
When connection gets refused the 40 retries happen back to back, causing
the script to timeout. Adding an explicit sleep to handle this instead
of just the connectiontimeout option.

Signed-off-by: Raghu Raja <craghun@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
