### PR TITLE
Slave nodes created using AWS CLI commands

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+create_instance()
+{
+    INSTANCE_IDS=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 run-instances --tag-specification 'ResourceType=instance,Tags=[{Key=Type,Value=Slave},{Key=Name,Value=Slave}]' --image-id ${ami[0]} --instance-type ${instance_type} --enable-api-termination --key-name ${slave_keypair} --security-group-id ${slave_security_group} --subnet-id ${subnet_id} --placement AvailabilityZone=${availability_zone} --count ${NODES}:${NODES} --query "Instances[*].InstanceId" --output=text)
+}
+
+# Holds testing every 15 seconds for 40 attempts until the instance status check is ok
+test_instance_status()
+{
+    aws ec2 wait instance-status-ok --instance-ids $1
+}
+
+# Get IP address for instances
+get_instance_ip()
+{
+    INSTANCE_IPS=$(aws ec2 describe-instances --instance-ids ${INSTANCE_IDS[@]} --query "Reservations[*].Instances[*].PrivateIpAddress" --output=text)
+}
+
+# Prepares AMI specific script, this includes installation commands and adding libfabric script
+installation_script()
+{
+    set_var
+    ${label}_install
+    cat install-libfabric.sh >> ${label}.sh
+}
+
+alinux_install()
+{
+    cat <<-"EOF" >>${label}.sh
+    sudo yum -y update
+    sudo yum -y groupinstall 'Development Tools'
+EOF
+}
+
+rhel_install()
+{
+    alinux_install
+    cat <<-EOF >>${label}.sh
+EOF
+}
+
+ubuntu_install()
+{
+    cat <<-"EOF" >> ${label}.sh
+    sudo apt-get update
+    sudo apt -y install python
+    sudo apt -y install autoconf
+    sudo apt -y install libltdl-dev
+    sudo apt -y install make
+EOF
+}
+
+#Initialize variables
+set_var()
+{
+    cat <<-"EOF" > ${label}.sh
+    #!/bin/bash
+    set +x
+    PULL_REQUEST_ID=$1
+    PULL_REQUEST_REF=$2
+    PROVIDER=$3
+    echo "==>Installing OS specific packages"
+EOF
+}
+
+# Poll for the SSH daemon to come up before proceeding. The SSH poll retries 40 times with a 5-second timeout each time,
+# which should be plenty after `instance-status-ok`. SSH into nodes and install libfabric
+test_ssh()
+{
+    slave_ready=''
+    slave_poll_count=0
+    while [ ! $slave_ready ] && [ $slave_poll_count -lt 40 ] ; do
+        echo "Waiting for slave instance to become ready"
+        sleep 5
+        ssh -T -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o BatchMode=yes -i ~/${slave_keypair} ${ami[1]}@$1  hostname
+        if [ $? -eq 0 ]; then
+            slave_ready='1'
+        fi
+        slave_poll_count=$((slave_poll_count+1))
+    done
+}
+
+export -f create_instance
+export -f test_instance_status
+export -f get_instance_ip
+export -f installation_script
+export -f test_ssh

--- a/install-libfabric.sh
+++ b/install-libfabric.sh
@@ -1,5 +1,6 @@
 echo "==> Building libfabric"
 # Pulls the libfabric repository and checks out the pull request commit
+cd ${HOME}
 git clone https://github.com/ofiwg/libfabric
 cd ${HOME}/libfabric
 git fetch origin +refs/pull/$PULL_REQUEST_ID/*:refs/remotes/origin/pr/$PULL_REQUEST_ID/*

--- a/install-libfabric.sh
+++ b/install-libfabric.sh
@@ -1,0 +1,34 @@
+echo "==> Building libfabric"
+# Pulls the libfabric repository and checks out the pull request commit
+git clone https://github.com/ofiwg/libfabric
+cd ${HOME}/libfabric
+git fetch origin +refs/pull/$PULL_REQUEST_ID/*:refs/remotes/origin/pr/$PULL_REQUEST_ID/*
+git checkout $PULL_REQUEST_REF -b PRBranch
+./autogen.sh
+./configure --prefix=${HOME}/libfabric/install/ \
+    --enable-debug  \
+    --enable-mrail  \
+    --enable-tcp    \
+    --enable-rxm    \
+    --disable-rxd
+make -j 4
+make install
+echo "==> Building fabtests"
+cd ${HOME}/libfabric/fabtests
+./autogen.sh
+./configure --with-libfabric=${HOME}/libfabric/install/ \
+    --prefix=${HOME}/libfabric/fabtests/install/ \
+    --enable-debug
+make -j 4
+make install
+
+# Runs all the tests in the fabtests suite between two nodes while only expanding failed cases
+EXCLUDE=${HOME}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.exclude
+if [ -f ${EXCLUDE} ]; then
+    EXCLUDE="-R -f ${EXCLUDE}"
+else
+    EXCLUDE=""
+fi
+export LD_LIBRARY_PATH=${HOME}/libfabric/install/lib/:$LD_LIBRARY_PATH >> ~/.bash_profile
+export BIN_PATH=${HOME}/libfabric/fabtests/install/bin/ >> ~/.bash_profile
+export PATH=${HOME}/libfabric/fabtests/install/bin:$PATH >> ~/.bash_profile

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -1,96 +1,87 @@
-#!/bin/sh
+#!/bin/bash
 
 set +x
+source $WORKSPACE/libfabric-ci-scripts/common.sh
+slave_name=slave_$label
+slave_value=${!slave_name}
+ami=($slave_value)
+REMOTE_DIR=/home/${ami[1]}
+NODES=2
+BUILD_CODE=0
 
-# Uses curl meta-data to retrieve identical information for instance creation
-AMI_ID=$(curl http://169.254.169.254/latest/meta-data/ami-id)
-AVAILABILITY_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
-INSTANCE_TYPE=$(curl http://169.254.169.254/latest/meta-data/instance-type)
-SECURITY_GROUPS=$(curl http://169.254.169.254/latest/meta-data/security-groups)
-KEY_NAME=$(curl http://169.254.169.254/latest/meta-data/public-keys/ | sed -e 's,0=,,g')
-CLIENT_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+# Test whether the instance is ready for SSH or not. Once the instance is ready,
+# copy SSH keys from Jenkins and install libfabric
+install_libfabric()
+{
+    test_ssh "$1"
+    scp -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/id_rsa $WORKSPACE/libfabric-ci-scripts/id_rsa.pub ${ami[1]}@$1:~/.ssh/
+    ssh -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@$1 "bash -s" -- < $WORKSPACE/libfabric-ci-scripts/${label}.sh "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER"
+}
 
-# Launches an identical instance and sets ID and IP environment variables for the instance
-echo "==> Launching instance"
-VOLUME=$(curl http://169.254.169.254/latest/meta-data/block-device-mapping/root)
-SERVER_ID=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 run-instances --tag-specification 'ResourceType=instance,Tags=[{Key=Type,Value=Slave},{Key=Name,Value=Slave}]' --image-id $AMI_ID --instance-type $INSTANCE_TYPE --enable-api-termination --key-name $KEY_NAME --security-groups $SECURITY_GROUPS --placement AvailabilityZone=$AVAILABILITY_ZONE --query "Instances[*].InstanceId"   --output=text)
-# Occasionally needs to wait before describe instances may be called
-
-for i in `seq 1 40`;
-do
-  SERVER_IP=$(aws ec2 describe-instances --instance-ids $SERVER_ID --query "Reservations[*].Instances[*].PrivateIpAddress" --output=text) && break || sleep 5;
-done
-
-# Pulls the libfabric repository and checks out the pull request commit
-echo "==> Building libfabric on first node"
-cd $WORKSPACE
-git clone https://github.com/ofiwg/libfabric
-cd libfabric
-git fetch origin +refs/pull/$PULL_REQUEST_ID/*:refs/remotes/origin/pr/$PULL_REQUEST_ID/*
-git checkout $PULL_REQUEST_REF -b PRBranch
-./autogen.sh
-./configure --prefix=$WORKSPACE/libfabric/install/ --enable-debug --enable-mrail --enable-tcp --enable-rxm --disable-rxd
-make -j 4
-sudo make install
-
-echo "==> Building fabtests"
-cd $WORKSPACE/libfabric/fabtests
-./autogen.sh
-./configure --with-libfabric=$WORKSPACE/libfabric/install/ --prefix=$WORKSPACE/fabtests/install/ --enable-debug
-make -j 4
-sudo make install
-
-# Wait for the slave instance status to become OK, and poll for the SSH daemon
-# to come up before proceeding. EC2 wait retries every 15 seconds for 40
-# attempts. The SSH poll retries 40 times with a 5-second timeout each time,
-# which should be plenty after `instance-status-ok`.
-slave_ready=''
-slave_poll_count=0
-aws ec2 wait instance-status-ok --instance-ids $SERVER_ID
-while [ ! $slave_ready ] && [ $slave_poll_count -lt 40 ] ; do
-    echo "Waiting for slave instance to become ready"
-    sleep 5
-    ssh -T -o ConnectTimeout=1 -o StrictHostKeyChecking=no -o BatchMode=yes $USER@$SERVER_IP hostname
-    if [ $? -eq 0 ]; then
-      slave_ready='1'
+# Runs fabtests on client nodes using INSTANCE_IPS[0] as server
+execute_runfabtests()
+{
+ssh -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} <<-EOF && { echo "Build success on ${INSTANCE_IPS[$1]}" ; echo "EXIT_CODE=0" > $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IDS[$1]}.sh; } || { echo "Build failed on ${INSTANCE_IPS[$1]}"; echo "EXIT_CODE=1" > $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IDS[$1]}.sh; }
+    # Runs all the tests in the fabtests suite while only expanding failed cases
+    EXCLUDE=${REMOTE_DIR}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.EXCLUDE
+    if [ -f ${EXCLUDE} ]; then
+        EXCLUDE="-R -f ${EXCLUDE}"
+    else
+        EXCLUDE=""
     fi
-    slave_poll_count=$((slave_poll_count+1))
+    export LD_LIBRARY_PATH=${REMOTE_DIR}/libfabric/install/lib/:$LD_LIBRARY_PATH >> ~/.bash_profile
+    export BIN_PATH=${REMOTE_DIR}/libfabric/fabtests/install/bin/ >> ~/.bash_profile
+    export PATH=${REMOTE_DIR}/libfabric/fabtests/install/bin:$PATH >> ~/.bash_profile
+    ${REMOTE_DIR}/libfabric/fabtests/install/bin/runfabtests.sh -v ${EXCLUDE} ${PROVIDER} ${INSTANCE_IPS[0]} ${INSTANCE_IPS[$1]}
+EOF
+}
+
+create_instance
+INSTANCE_IDS=($INSTANCE_IDS)
+
+# Wait until all instances have passed status check
+for ID in ${INSTANCE_IDS[@]}
+do
+    test_instance_status "$ID" &
+done
+wait
+
+get_instance_ip
+INSTANCE_IPS=($INSTANCE_IPS)
+
+# Prepare AMI specific libfabric installation script
+installation_script
+
+# Generate ssh key for fabtests
+ssh-keygen -f $WORKSPACE/libfabric-ci-scripts/id_rsa -N "" > /dev/null
+cat <<-"EOF" >>${label}.sh
+    cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+    chmod 600  ~/.ssh/id_rsa
+EOF
+
+# SSH into nodes and install libfabric concurrently on all nodes
+for IP in ${INSTANCE_IPS[@]}
+do
+    install_libfabric "$IP" &
+done
+wait
+
+# SSH into SERVER node and run fabtests
+N=$((${#INSTANCE_IPS[@]}-1))
+for i in $(seq 1 $N)
+do
+    execute_runfabtests "$i"
 done
 
-# Adds the IP's to the respective known hosts
-ssh-keyscan -H -t rsa $SERVER_IP  >> ~/.ssh/known_hosts
-ssh -T -o StrictHostKeyChecking=no $USER@$SERVER_IP <<-EOF && { echo "Build success" ; EXIT_CODE=0 ; } || { echo "Build failed"; EXIT_CODE=1 ;}
-  ssh-keyscan -H -t rsa $CLIENT_IP  >> ~/.ssh/known_hosts
-  echo "==> Building libfabric on second node"
-  cd ~
-  mkdir -p $WORKSPACE
-  cd $WORKSPACE
-  git clone https://github.com/ofiwg/libfabric
-  cd libfabric
-  git fetch origin +refs/pull/$PULL_REQUEST_ID/*:refs/remotes/origin/pr/$PULL_REQUEST_ID/*
-  git checkout $PULL_REQUEST_REF -b PRBranch
-  ./autogen.sh
-  ./configure --prefix=$WORKSPACE/libfabric/install/ --enable-debug --enable-mrail --enable-tcp --enable-rxm --disable-rxd
-  make -j 4
-  make install
-  echo "==> Building fabtests on second node"
-  cd $WORKSPACE/libfabric/fabtests
-  ./autogen.sh
-  ./configure --with-libfabric=$WORKSPACE/libfabric/install/ --prefix=$WORKSPACE/fabtests/install/ --enable-debug
-  make -j 4
-  make install
-  # Runs all tests in the fabtests suite between two nodes while only expanding
-  # failed cases
-  echo "==> Running fabtests between two nodes"
-  EXCLUDE=$WORKSPACE/fabtests/install/share/fabtests/test_configs/$PROVIDER/${PROVIDER}.exclude
-  if [ -f $EXCLUDE ]; then
-  	EXCLUDE="-R -f $EXCLUDE"
-  else
-  	EXCLUDE=""
-  fi
-  LD_LIBRARY_PATH=$WORKSPACE/fabtests/install/lib/:$LD_LIBRARY_PATH BIN_PATH=$WORKSPACE/fabtests/install/bin/ FI_LOG_LEVEL=debug $WORKSPACE/fabtests/install/bin/runfabtests.sh -v $EXCLUDE $PROVIDER $CLIENT_IP $SERVER_IP
-EOF
-# Terminates second node. First node will be terminated in a post build task to
-# prevent build failure
-AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids $SERVER_ID
-exit $EXIT_CODE
+# Get build status
+for i in $(seq 1 $N)
+do
+    source $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IDS[$i]}.sh
+    if [ $EXIT_CODE -ne 0 ];then
+        BUILD_CODE=1
+    fi
+done
+
+# Terminates all slave nodes
+AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids ${INSTANCE_IDS[@]}
+exit ${BUILD_CODE}


### PR DESCRIPTION
Single-node.sh and multi-node.sh scripts generate EC2 instances using
AWS CLI commands. Libfabric installation commands are loaded from
install-libfabric.sh Multi-node.sh can be used to build multiple nodes
not limited to two. Currently the value NODES is hardcoded to two, this
can be modified. While libfabric is loaded in parallel on all nodes,
fabtests is run sequentially.

Signed-off-by: dkothar <dkothar@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
