### PR TITLE
EFA log

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 # Launches EC2 instances.
 create_instance()
 {
@@ -93,7 +94,7 @@ set_var()
 {
     cat <<-"EOF" > ${label}.sh
     #!/bin/bash
-    set +x
+    set -x
     PULL_REQUEST_ID=$1
     PULL_REQUEST_REF=$2
     PROVIDER=$3
@@ -107,6 +108,7 @@ test_ssh()
 {
     slave_ready=''
     slave_poll_count=0
+    set +x
     while [ ! $slave_ready ] && [ $slave_poll_count -lt 40 ] ; do
         echo "Waiting for slave instance to become ready"
         sleep 5
@@ -116,6 +118,7 @@ test_ssh()
         fi
         slave_poll_count=$((slave_poll_count+1))
     done
+    set -x
 }
 
 efa_software_components()
@@ -132,6 +135,7 @@ ubuntu_kernel_upgrade()
 {
     test_ssh $1
     cat <<-"EOF" > ubuntu_kernel_upgrade.sh
+    set -x
     echo "==>System will reboot after kernel upgrade"
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y --with-new-pkgs -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade

--- a/common.sh
+++ b/common.sh
@@ -137,5 +137,17 @@ ubuntu_kernel_upgrade()
     sudo DEBIAN_FRONTEND=noninteractive apt-get -y --with-new-pkgs -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
     sudo reboot
 EOF
-    ssh -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@"$1" "bash -s" -- < $WORKSPACE/libfabric-ci-scripts/ubuntu_kernel_upgrade.sh
+    ssh -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@"$1" \
+        "bash -s" -- < $WORKSPACE/libfabric-ci-scripts/ubuntu_kernel_upgrade.sh \
+        2>&1 | tr \\r \\n | sed 's/\(.*\)/'$1' \1/'
+}
+
+exit_status()
+{
+    if [ $1 -ne 0 ];then
+        BUILD_CODE=1
+        echo "Build failure on $2"
+    else
+        echo "Build success on $2"
+    fi
 }

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -60,7 +60,7 @@ execute_runfabtests()
         { echo "Build failed on ${INSTANCE_IPS[$1]}"; echo "EXIT_CODE=1" > $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IDS[$1]}.sh; }
 }
 
-create_instance
+create_instance || { echo "==>Unable to create instance"; exit 1; }
 INSTANCE_IDS=($INSTANCE_IDS)
 
 # Wait until all instances have passed status check

--- a/single-node.sh
+++ b/single-node.sh
@@ -7,7 +7,7 @@ slave_value=${!slave_name}
 ami=($slave_value)
 NODES=1
 
-create_instance
+create_instance || { echo "==>Unable to create instance"; exit 1; }
 test_instance_status ${INSTANCE_IDS}
 get_instance_ip
 

--- a/single-node.sh
+++ b/single-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set +x
+set -x
 source $WORKSPACE/libfabric-ci-scripts/common.sh
 slave_name=slave_$label
 slave_value=${!slave_name}
@@ -8,7 +8,9 @@ ami=($slave_value)
 NODES=1
 BUILD_CODE=0
 
+set +x
 create_instance || { echo "==>Unable to create instance"; exit 1; }
+set -x
 test_instance_status ${INSTANCE_IDS}
 get_instance_ip
 
@@ -35,10 +37,12 @@ test_ssh ${INSTANCE_IPS}
 
 # For single node, the ssh connection is established only once. The script
 # builds libfabric and also executes fabtests
+set +x
 ssh -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS} \
     "bash -s" -- <$WORKSPACE/libfabric-ci-scripts/${label}.sh \
     "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'${INSTANCE_IPS}' \1/'
 EXIT_CODE=${PIPESTATUS[0]}
+set -x
 
 # Get build status
 exit_status "$EXIT_CODE" "${INSTANCE_IPS}"


### PR DESCRIPTION
Previously, if run-instances failed random IPs were being generated and the script was running on these random IPs. Added a check to exit, if the above situation occurs
Multi-node logs are interleaved, for readability corresponding IPs have been added at the beginning of each line.
To support debugging, the executed commands are printed in the log.
   
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
