### PR TITLE
Adding Travis CI for PR linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+dist: trusty
+language: bash
+
+addons:
+  apt:
+    sources:
+    - sourceline: 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse'
+    packages:
+    - shellcheck
+
+before_install:
+    - sudo pip install bashate
+
+script:
+- bashate *.sh
+- # Commenting out shell-check till we fully resolve existing warnings
+- # shellcheck -S warning *.sh

--- a/common.sh
+++ b/common.sh
@@ -21,10 +21,8 @@ create_instance()
             exit 1
     esac
     echo "==> Creating instances"
-    while [ ${error} -ne 0 ] && [ ${create_instance_count} -lt 30 ]
-    do
-        for subnet in ${subnet_ids[@]}
-        do
+    while [ ${error} -ne 0 ] && [ ${create_instance_count} -lt 30 ]; do
+        for subnet in ${subnet_ids[@]}; do
             error=1
             INSTANCE_IDS=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 run-instances \
                     --tag-specification 'ResourceType=instance,Tags=[{Key=Type,Value=Slave},{Key=Name,Value=Slave}]' \
@@ -92,7 +90,7 @@ script_builder()
     set_var
     ${label}_install
     if [ ${PROVIDER} == "efa" ]; then
-         efa_software_components
+        efa_software_components
     fi
     cat install-libfabric.sh >> ${label}.sh
 }

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -73,8 +73,7 @@ set -x
 INSTANCE_IDS=($INSTANCE_IDS)
 
 # Wait until all instances have passed status check
-for ID in ${INSTANCE_IDS[@]}
-do
+for ID in ${INSTANCE_IDS[@]}; do
     test_instance_status "$ID" &
 done
 wait
@@ -97,8 +96,7 @@ EOF
 set -x
 
 # SSH into nodes and install libfabric concurrently on all nodes
-for IP in ${INSTANCE_IPS[@]}
-do
+for IP in ${INSTANCE_IPS[@]}; do
     install_libfabric "$IP" &
 done
 wait
@@ -108,14 +106,12 @@ runfabtests_script_builder
 
 # SSH into SERVER node and run fabtests
 N=$((${#INSTANCE_IPS[@]}-1))
-for i in $(seq 1 $N)
-do
+for i in $(seq 1 $N); do
     execute_runfabtests "$i"
 done
 
 # Get build status
-for i in $(seq 1 $N)
-do
+for i in $(seq 1 $N); do
     source $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IDS[$i]}.sh
     exit_status "$EXIT_CODE" "${INSTANCE_IPS[$i]}"
 done


### PR DESCRIPTION
Added a simple Travis config that lints changes to the bash scripts for style and errors. Bashate and shellcheck are used, but the latter is currently commented out until all the known warnings are fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
