### PR TITLE
Add and remove tags from slave nodes for post build termination

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -25,7 +25,7 @@ create_instance()
         for subnet in ${subnet_ids[@]}; do
             error=1
             INSTANCE_IDS=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 run-instances \
-                    --tag-specification 'ResourceType=instance,Tags=[{Key=Type,Value=Slave},{Key=Name,Value=Slave}]' \
+                    --tag-specification "ResourceType=instance,Tags=[{Key=Workspace,Value="${WORKSPACE}"},{Key=Name,Value=Slave},{Key=Build_Number,Value="${BUILD_NUMBER}"}]" \
                     --image-id ${ami[0]} \
                     --instance-type ${instance_type} \
                     --enable-api-termination \


### PR DESCRIPTION
Added two tags for slave node, the execution number and the workspace
path. This will be helpful in identifying the instance during post build
task. Removed tag with key=Type and value=Slave, this is redundant as it
stores the same value as key=Name.

Approved CR:https://code.amazon.com/reviews/CR-11581502/revisions/1#/details

Signed-off-by: dkothar <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
