### PR TITLE
Instance Termination and Junit Log creation

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -x
+BUILD_CODE=0
+
 # Launches EC2 instances.
 create_instance()
 {

--- a/common.sh
+++ b/common.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 set -x
+trap 'on_exit'  EXIT
+execution_seq=1
 BUILD_CODE=0
 
 # Launches EC2 instances.
@@ -63,18 +65,24 @@ create_instance()
         sleep 2m
         create_instance_count=$((create_instance_count+1))
     done
+    echo -n > $WORKSPACE/libfabric-ci-scripts/${execution_seq}_0_create_instance.txt
 }
 
 # Holds testing every 15 seconds for 40 attempts until the instance status check is ok
 test_instance_status()
 {
-    aws ec2 wait instance-status-ok --instance-ids $1
+    aws ec2 wait instance-status-ok --instance-ids $1 \
+    > $WORKSPACE/libfabric-ci-scripts/${execution_seq}_$1_test_instance_status.txt 2>&1
 }
 
 # Get IP address for instances
 get_instance_ip()
 {
-    INSTANCE_IPS=$(aws ec2 describe-instances --instance-ids ${INSTANCE_IDS[@]} --query "Reservations[*].Instances[*].PrivateIpAddress" --output=text)
+    execution_seq=$((${execution_seq}+1))
+    INSTANCE_IPS=$(aws ec2 describe-instances --instance-ids ${INSTANCE_IDS[@]} \
+                        --query "Reservations[*].Instances[*].PrivateIpAddress" \
+                        --output=text 2>&1 | \
+                        tee $WORKSPACE/libfabric-ci-scripts/${execution_seq}_0_get_instance_ip.txt )
 }
 
 # Check provider and OS type, If EFA and Ubuntu then call ubuntu_kernel_upgrade
@@ -139,18 +147,19 @@ EOF
 # which should be plenty after `instance-status-ok`. SSH into nodes and install libfabric
 test_ssh()
 {
-    slave_ready=''
+    slave_ready=1
     slave_poll_count=0
     set +x
-    while [ ! $slave_ready ] && [ $slave_poll_count -lt 40 ] ; do
+    while [ $slave_ready -ne 0 ] && [ $slave_poll_count -lt 40 ] ; do
         echo "Waiting for slave instance to become ready"
         sleep 5
         ssh -T -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o BatchMode=yes -i ~/${slave_keypair} ${ami[1]}@$1  hostname
         if [ $? -eq 0 ]; then
-            slave_ready='1'
+            slave_ready=0
         fi
         slave_poll_count=$((slave_poll_count+1))
     done
+    echo "Slave instance ssh exited with status ${slave_ready}" > $WORKSPACE/libfabric-ci-scripts/${execution_seq}_$1_test_ssh.txt
     set -x
 }
 
@@ -177,6 +186,138 @@ EOF
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@"$1" \
         "bash -s" -- < $WORKSPACE/libfabric-ci-scripts/ubuntu_kernel_upgrade.sh \
         2>&1 | tr \\r \\n | sed 's/\(.*\)/'$1' \1/'
+    execution_seq=$((${execution_seq}+1))
+}
+
+# Download the fabtest parser file and modify it locally to show results for
+# Excluded files as skipped as well. Currently only Notrun files are displayed
+# as skipped
+get_rft_yaml_to_junit_xml()
+{
+    # fabtests junit parser script
+    wget https://raw.githubusercontent.com/ofiwg/libfabric/master/fabtests/scripts/rft_yaml_to_junit_xml
+    # Add Excluded tag
+    sed -i "s,<skipped />,<skipped />\n    EOT\n  when 'Excluded'\n    puts <<-EOT\n    <skipped />,g" $WORKSPACE/libfabric-ci-scripts/rft_yaml_to_junit_xml
+    sed -i "s,skipped += 1,skipped += 1\n  when 'Excluded'\n    skipped += 1,g" $WORKSPACE/libfabric-ci-scripts/rft_yaml_to_junit_xml
+}
+
+# Split out output files into fabtest build and fabtests, this is done to
+# separate the output. As long as INSTANCE_IPS[0] is used, this can be
+# common for both single node and multinode
+split_files()
+{
+    csplit -k $WORKSPACE/libfabric-ci-scripts/temp_execute_runfabtests.txt '/- name/'
+    if [ $? -ne 0 ]; then
+        execution_seq=$((${execution_seq}+1))
+        mv $WORKSPACE/libfabric-ci-scripts/temp_execute_runfabtests.txt $WORKSPACE/libfabric-ci-script/${execution_seq}_${INSTANCE_IPS[0]}_install_libfabric_or_fabtests_parameters.txt
+    else
+        execution_seq=$((${execution_seq}+1))
+        mv $WORKSPACE/libfabric-ci-scripts/xx00 $WORKSPACE/libfabric-ci-scripts/${execution_seq}_${INSTANCE_IPS[0]}_install_libfabric_or_fabtests_parameters.txt
+        execution_seq=$((${execution_seq}+1))
+        mv $WORKSPACE/libfabric-ci-scripts/xx01 $WORKSPACE/libfabric-ci-scripts/${execution_seq}_${INSTANCE_IPS[0]}_fabtests.txt
+    fi
+    rm temp_execute_runfabtests.txt
+}
+# Parses the output text file to yaml and then runs rft_yaml_to_junit_xml script
+# to generate junit xml file. Calls parse_fabtests function for fabtests result.
+# For general text file assign commands yaml -name tags, the output of these
+# commands will be assigned server_stdout tag
+parse_txt_junit_xml()
+{
+    exit_code=$?
+    set +x
+    get_rft_yaml_to_junit_xml
+    # Read all .txt files
+    for file in *.txt; do
+        if [[ ${file} == '*.txt' ]]; then
+            break
+        fi
+        # Get instance id or instance ip from the file name
+        instance_ip_or_id=($(echo ${file} | tr "_" "\n"))
+        N=${#instance_ip_or_id[@]}
+        file_name=${file/.txt/}
+        # Line number to arrange commands sequentially
+        line_no=1
+        # If the first line of the file does not have a + (+ indicates command)
+        # then insert ip/id and + only if its not empty, this is only for non
+        # fabtests.txt file
+        if [[ ${instance_ip_or_id[$(($N-1))]} != 'fabtests.txt' ]]; then
+            sed -i "1s/\(${instance_ip_or_id[1]} [+]\+ \)*\(.\+\)/${instance_ip_or_id[1]} + \2/g" ${file}
+        else
+            parse_fabtests ${file}
+            break
+        fi
+        while read line; do
+            # If the line is a command indicated by + sign then assign name tag
+            # to it, command is the testname used in the xml
+            if [[ ${line} == *${instance_ip_or_id[1]}' +'* ]]; then
+                # Junit deosn't accept quotes or colons in testname in the xml, convert
+                # them to underscores. Parse the command to yaml, by inserting
+                # - name tag before the command
+                echo ${line//[\":]/_} | sed "s/\(${instance_ip_or_id[1]} [+]\+\)\(.*\)/- name: $(printf '%08d\n' $line_no)-\2\n  time: 0\n  result:\n  server_stdout: |/g" \
+                >> $WORKSPACE/libfabric-ci-scripts/${file_name}
+                line_no=$((${line_no}+1))
+            else
+                # These are output lines and are put under server_stdout tag
+                echo "    "${line}  >> $WORKSPACE/libfabric-ci-scripts/${file_name}
+            fi
+        done < ${file}
+        junit_xml ${file_name}
+    done
+    set -x
+}
+
+# Parses the fabtest result to xml. One change has been done to accomodate yaml
+# file creation if fabtest fails. All output other than name,time,result will be
+# grouped under server_stdout.
+parse_fabtests()
+{
+    while read line; do
+        # If the line has - name: it indicates its a fabtests command and is
+        # already yaml format, it already has name tag. It is the testname
+        # used in the xml
+        if [[ ${line} == *${instance_ip_or_id[1]}' - 'name:* ]]; then
+            echo ${line//[\"]/_} | sed "s/\(${instance_ip_or_id[1]} [-] name: \)\(.*\)/- name: \2/g" >> $WORKSPACE/libfabric-ci-scripts/${file_name}
+        elif [[ ${line} == *'time: '* ]]; then
+            echo ${line} | sed "s/\(${instance_ip_or_id[1]}\)\(.*time:.*\)/ \2\n  server_stdout: |/g" >> $WORKSPACE/libfabric-ci-scripts/${file_name}
+        else
+            # Yaml spacing for result tag should be aligned with name,
+            # time, server_stdout tags; whereas all other should be under
+            # server_stdout tag
+            echo ${line} | sed "s/\(${instance_ip_or_id[1]}\)\(.*\(result\):.*\)*\(.*\)/ \2  \4/g" >> $WORKSPACE/libfabric-ci-scripts/${file_name}
+        fi
+        line_no=$((${line_no}+1))
+    done < $1
+    junit_xml ${file_name}
+}
+
+# It updates the filename in rft_yaml_to_junit_xml on the fly to the file_name
+# which is the function_name. If the file is empty it doesn't call the
+# rft_yaml_to_junit_xml instead creates the xml itself
+junit_xml()
+{
+    file_name=$1
+    file_name_xml=${file_name//[.-]/_}
+    # If the yaml file is not empty then convert it to xml using
+    # rft_yaml_to_junit_xml else create an xml for empty yaml
+    if [ -s $WORKSPACE/libfabric-ci-scripts/${file_name} ]; then
+        sed -i "s/\(testsuite name=\)\(.*\)\(tests=\)/\1\"${file_name_xml}\" \3/g" $WORKSPACE/libfabric-ci-scripts/rft_yaml_to_junit_xml
+        ruby $WORKSPACE/libfabric-ci-scripts/rft_yaml_to_junit_xml < $WORKSPACE/libfabric-ci-scripts/${file_name} > ${file_name_xml}.xml || true
+    else
+        cat<<-EOF > $WORKSPACE/libfabric-ci-scripts/${file_name_xml}.xml
+<testsuite name="${file_name_xml}" tests="${file_name_xml}" skipped="0" time="0.000">
+    <testcase name="${file_name_xml}" time="0">
+    </testcase>
+</testsuite>
+EOF
+    fi
+}
+
+on_exit()
+{
+    set +e
+    split_files
+    parse_txt_junit_xml
 }
 
 exit_status()

--- a/common.sh
+++ b/common.sh
@@ -313,11 +313,20 @@ EOF
     fi
 }
 
+terminate_instances()
+{
+    # Terminates slave node
+    if [[ ! -z ${INSTANCE_IDS[@]} ]]; then
+        AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids ${INSTANCE_IDS[@]}
+    fi
+}
+
 on_exit()
 {
     set +e
     split_files
     parse_txt_junit_xml
+    terminate_instances
 }
 
 exit_status()

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -121,6 +121,4 @@ for i in $(seq 1 $N); do
     exit_status "$EXIT_CODE" "${INSTANCE_IPS[$i]}"
 done
 
-# Terminates all slave nodes
-AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids ${INSTANCE_IDS[@]}
 exit ${BUILD_CODE}

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -5,9 +5,7 @@ source $WORKSPACE/libfabric-ci-scripts/common.sh
 slave_name=slave_$label
 slave_value=${!slave_name}
 ami=($slave_value)
-REMOTE_DIR=/home/${ami[1]}
 NODES=2
-BUILD_CODE=0
 
 # Test whether the instance is ready for SSH or not. Once the instance is ready,
 # copy SSH keys from Jenkins and install libfabric

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -27,7 +27,7 @@ install_libfabric()
 runfabtests_script_builder()
 {
     cat <<-"EOF" > multinode_runfabtests.sh
-    set -x
+    set -xe
     PROVIDER=$1
     SERVER_IP=$2
     CLIENT_IP=$3

--- a/nccl.sh
+++ b/nccl.sh
@@ -1,0 +1,5 @@
+#!bin/bash/
+
+# Placeholder script for NCCL tests
+
+echo "NCCL Test"

--- a/single-node.sh
+++ b/single-node.sh
@@ -10,9 +10,13 @@ NODES=1
 set +x
 create_instance || { echo "==>Unable to create instance"; exit 1; }
 set -x
+
+execution_seq=$((${execution_seq}+1))
 test_instance_status ${INSTANCE_IDS}
+
 get_instance_ip
 
+execution_seq=$((${execution_seq}+1))
 # Kernel upgrade only for Ubuntu and provider EFA
 check_provider_os ${INSTANCE_IPS}
 
@@ -25,21 +29,23 @@ ssh-keygen -f ${HOME}/.ssh/id_rsa -N "" > /dev/null
 cat ${HOME}/.ssh/id_rsa.pub >> ${HOME}/.ssh/authorized_keys
 if [ ${PROVIDER} == "efa" ];then
     gid=$(cat /sys/class/infiniband/efa_0/ports/1/gids/0)
-    ${HOME}/libfabric/fabtests/install/bin/runfabtests.sh -v -t all -C "-P 0" -s $gid -c $gid ${EXCLUDE} ${PROVIDER} 127.0.0.1 127.0.0.1
+    ${HOME}/libfabric/fabtests/install/bin/runfabtests.sh -vvv -t all -C "-P 0" -s $gid -c $gid ${EXCLUDE} ${PROVIDER} 127.0.0.1 127.0.0.1
 else
-    ${HOME}/libfabric/fabtests/install/bin/runfabtests.sh -v ${EXCLUDE} ${PROVIDER} 127.0.0.1 127.0.0.1
+    ${HOME}/libfabric/fabtests/install/bin/runfabtests.sh -vvv ${EXCLUDE} ${PROVIDER} 127.0.0.1 127.0.0.1
 fi
 EOF
 
 # Test whether node is ready for SSH connection or not
 test_ssh ${INSTANCE_IPS}
 
+execution_seq=$((${execution_seq}+1))
 # For single node, the ssh connection is established only once. The script
 # builds libfabric and also executes fabtests
 set +x
 ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS} \
     "bash -s" -- <$WORKSPACE/libfabric-ci-scripts/${label}.sh \
-    "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'${INSTANCE_IPS}' \1/'
+    "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" 2>&1 | tr \\r \\n | \
+    sed 's/\(.*\)/'${INSTANCE_IPS}' \1/' | tee $WORKSPACE/libfabric-ci-scripts/temp_execute_runfabtests.txt
 EXIT_CODE=${PIPESTATUS[0]}
 set -x
 

--- a/single-node.sh
+++ b/single-node.sh
@@ -6,7 +6,6 @@ slave_name=slave_$label
 slave_value=${!slave_name}
 ami=($slave_value)
 NODES=1
-BUILD_CODE=0
 
 set +x
 create_instance || { echo "==>Unable to create instance"; exit 1; }

--- a/single-node.sh
+++ b/single-node.sh
@@ -51,7 +51,4 @@ set -x
 
 # Get build status
 exit_status "$EXIT_CODE" "${INSTANCE_IPS}"
-
-# Terminates slave node
-AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids ${INSTANCE_IDS}
 exit ${BUILD_CODE}


### PR DESCRIPTION
For Junit Logs the CI stack needs to updated, the scripts just creates the XML files. The junit plugin is responsible for displaying them.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
