### PR TITLE
Disable ptrace protection for Ubuntu jobs

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -140,6 +140,10 @@ check_provider_os()
 {
     if [ ${PROVIDER} == "efa" ] && [ ${label} == "ubuntu" ];then
         ubuntu_kernel_upgrade "$1"
+
+        # Ubuntu disallows non-child process ptrace by default, which is
+        # required for the use of CMA in the shared-memory codepath.
+        echo 0 > /proc/sys/kernel/yama/ptrace_scope
     fi
 }
 


### PR DESCRIPTION
Ubuntu disallows non-child process ptrace by default, which is required
for CMA to work in the shm provider. There is no fallback in shm in the
absence of CMA to a slowpath either, so disabling this is the only way
forward until a fallback is implemented.

Signed-off-by: Raghu Raja <craghun@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
