### PR TITLE
Use sysctl to update kernel.yama.ptrace_scope as sudo

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -143,7 +143,7 @@ check_provider_os()
 
         # Ubuntu disallows non-child process ptrace by default, which is
         # required for the use of CMA in the shared-memory codepath.
-        echo 0 > /proc/sys/kernel/yama/ptrace_scope
+        sudo sysctl -w kernel.yama.ptrace_scope=0
     fi
 }
 


### PR DESCRIPTION
The previous commit disabled ptrace protection, but this needs to be
done as a priviledged user. Using sysctl is cleaner than writing into
the /proc file as well.

Signed-off-by: Raghu Raja <craghun@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
