### PR TITLE
Fix issues with Open MPI using the wrong libfabric

### DIFF
--- a/install-fabtests.sh
+++ b/install-fabtests.sh
@@ -18,6 +18,11 @@ if [ -f ${EXCLUDE} ]; then
 else
     EXCLUDE=""
 fi
+# .bashrc and .bash_profile are loaded differently depending on distro and
+# whether the shell is interactive or not, just do both to be safe.
 echo "export LD_LIBRARY_PATH=${LIBFABRIC_INSTALL_PATH}/lib/:\$LD_LIBRARY_PATH" >> ~/.bash_profile
+echo "export LD_LIBRARY_PATH=${LIBFABRIC_INSTALL_PATH}/lib/:\$LD_LIBRARY_PATH" >> ~/.bashrc
 echo "export BIN_PATH=${HOME}/libfabric/fabtests/install/bin/" >> ~/.bash_profile
+echo "export BIN_PATH=${HOME}/libfabric/fabtests/install/bin/" >> ~/.bashrc
 echo "export PATH=${HOME}/libfabric/fabtests/install/bin:\$PATH" >> ~/.bash_profile
+echo "export PATH=${HOME}/libfabric/fabtests/install/bin:\$PATH" >> ~/.bashrc

--- a/install-libfabric.sh
+++ b/install-libfabric.sh
@@ -17,4 +17,5 @@ make -j 4
 make install
 LIBFABRIC_INSTALL_PATH=${HOME}/libfabric/install
 # ld.so.conf.d files are preferred in alphabetical order
+# this doesn't seem to be working for non-interactive shells
 sudo bash -c "echo ${LIBFABRIC_INSTALL_PATH} > /etc/ld.so.conf.d/aaaa-libfabric-testing.sh"

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -20,11 +20,15 @@ function check_efa_impi {
 function ompi_setup {
     . /etc/profile.d/efa.sh
     export OMPI_MCA_mtl_base_verbose=100
+    # Pass LD_LIBRARY_PATH arg so that we use the right libfabric. Ubuntu
+    # doesn't load .bashrc/.bash_profile for non-interactive shells.
+    export MPI_ARGS="-x LD_LIBRARY_PATH"
 }
 
 function impi_setup {
     source $IMPI_ENV
     export I_MPI_DEBUG=1
+    export MPI_ARGS=""
 }
 
 function host_setup {
@@ -41,5 +45,5 @@ function host_setup {
     export ranks=$(( $cpus / $threads ))
     # Avoid non-interactive shell PATH issues on Ubuntu with MPI by using full
     # path, so it can find orted.
-    export mpirun_path=$(which mpirun)
+    export mpirun_cmd="$(which mpirun) $MPI_ARGS"
 }

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -22,7 +22,8 @@ function ompi_setup {
     export OMPI_MCA_mtl_base_verbose=100
     # Pass LD_LIBRARY_PATH arg so that we use the right libfabric. Ubuntu
     # doesn't load .bashrc/.bash_profile for non-interactive shells.
-    export MPI_ARGS="-x LD_LIBRARY_PATH"
+    # Only load the OFI component so MPI will fail if it cannot be used.
+    export MPI_ARGS="-x LD_LIBRARY_PATH --mca mtl ofi"
 }
 
 function impi_setup {

--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -37,10 +37,10 @@ for host in $hosts; do
     scp -r ${osu_dir} $host:/tmp
 done
 
-$mpirun_path --version
+$mpirun_cmd --version
 
 # TODO: split this output so that it shows up as three separate tests in the xml output
-$mpirun_path -n 2 ${one_rank_per_node} -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_latency 2>&1 | tee $out
+$mpirun_cmd -n 2 ${one_rank_per_node} -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_latency 2>&1 | tee $out
 if [ $? -ne 0 ]; then
     echo "osu_latency failed"
     exit 1
@@ -52,7 +52,7 @@ elif [ "${mpi}" == "impi" ]; then
     check_efa_impi $out
 fi
 
-$mpirun_path -n 2 ${one_rank_per_node} -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_bw 2>&1 | tee $out
+$mpirun_cmd -n 2 ${one_rank_per_node} -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_bw 2>&1 | tee $out
 if [ $? -ne 0 ]; then
     echo "osu_bw failed"
     exit 1
@@ -64,7 +64,7 @@ elif [ "${mpi}" == "impi" ]; then
     check_efa_impi $out
 fi
 
-$mpirun_path -n $(( $ranks * $# )) -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_mbw_mr 2>&1 | tee $out
+$mpirun_cmd -n $(( $ranks * $# )) -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_mbw_mr 2>&1 | tee $out
 if [ $? -ne 0 ]; then
     echo "osu_mbw_mr failed"
     exit 1

--- a/mpi_ring_c_test.sh
+++ b/mpi_ring_c_test.sh
@@ -28,8 +28,8 @@ for host in $hosts; do
     scp /tmp/ring_c $host:/tmp
 done
 
-$mpirun_path --version
-$mpirun_path -n $(( $ranks * $# )) -hostfile $hostfile /tmp/ring_c 2>&1 | tee $out
+$mpirun_cmd --version
+$mpirun_cmd -n $(( $ranks * $# )) -hostfile $hostfile /tmp/ring_c 2>&1 | tee $out
 if [ $? -ne 0 ] || ! grep -q "Process 0 exiting" $out; then
     echo "mpirun ring_c failed"
     exit 1


### PR DESCRIPTION
Open MPI was using the system libfabric on the remote node instead of the compiled one, turns out the ld changes were not sufficient here. Rework the scripts so it's more explicit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
