### PR TITLE
Only use subnets that belong to the slave's VPC

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -91,7 +91,15 @@ delete_pg()
 # Launches EC2 instances.
 create_instance()
 {
-    subnet_ids=$(aws ec2 describe-subnets --filter "Name=availability-zone,Values=[us-west-2a,us-west-2b,us-west-2c]" --query "Subnets[*].SubnetId" --output=text)
+    # Get a list of subnets within the VPC relevant to the Slave SG
+    vpc_id=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 describe-security-groups \
+        --group-ids ${slave_security_group} \
+        --query SecurityGroups[0].VpcId --output=text)
+    subnet_ids=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 describe-subnets \
+        --filters "Name=availability-zone,Values=[us-west-2a,us-west-2b,us-west-2c]" \
+                    "Name=vpc-id,Values=$vpc_id" \
+                    --query "Subnets[*].SubnetId" --output=text)
+
     INSTANCE_IDS=''
     SERVER_ERROR=(InsufficientInstanceCapacity RequestLimitExceeded ServiceUnavailable Unavailable)
     create_instance_count=0


### PR DESCRIPTION
In the presence of multiple VPCs, the subnet selection logic was
erroneous in picking the first one in a query. With this commit, the
subnet list is filtered to only include those which belong to the VPC
tied to the slave's security group.

Signed-off-by: Raghu Raja <craghun@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
