### PR TITLE
Change the ssh key file name

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -18,7 +18,8 @@ install_libfabric()
     check_provider_os "$1"
     test_ssh "$1"
     set +x
-    scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/id_rsa $WORKSPACE/libfabric-ci-scripts/id_rsa.pub ${ami[1]}@$1:~/.ssh/
+    scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair} ${ami[1]}@$1:~/.ssh/id_rsa
+    scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair}.pub ${ami[1]}@$1:~/.ssh/id_rsa.pub
     execution_seq=$((${execution_seq}+1))
     (ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@$1 \
         "bash -s" -- < ${tmp_script} \
@@ -91,8 +92,8 @@ script_builder multi-node
 
 # Generate ssh key for fabtests
 set +x
-if [ ! -f $WORKSPACE/libfabric-ci-scripts/id_rsa ]; then
-    ssh-keygen -f $WORKSPACE/libfabric-ci-scripts/id_rsa -N "" > /dev/null
+if [ ! -f $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair} ]; then
+    ssh-keygen -f $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair} -N ""
 fi
 cat <<-"EOF" >>${tmp_script}
     set +x


### PR DESCRIPTION
Currently, the file

      $WORKSPACE/libfabric-ci-scripts/id_rsa

is used for running fabtests. This patch change the file name
to

      $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair}

to be more specific.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
