### PR TITLE
Force ubuntu to run apt in noninteractive mode

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -278,17 +278,17 @@ EOF
 ubuntu_update()
 {
     cat <<-"EOF" >> ${tmp_script}
-    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get update
 EOF
 }
 
 ubuntu_install_deps()
 {
     cat <<-"EOF" >> ${tmp_script}
-    sudo apt -y install python
-    sudo apt -y install autoconf
-    sudo apt -y install libltdl-dev
-    sudo apt -y install make
+    sudo DEBIAN_FRONTEND=noninteractive apt -y install python
+    sudo DEBIAN_FRONTEND=noninteractive apt -y install autoconf
+    sudo DEBIAN_FRONTEND=noninteractive apt -y install libltdl-dev
+    sudo DEBIAN_FRONTEND=noninteractive apt -y install make
 EOF
 }
 


### PR DESCRIPTION
Currently while installing python, ubuntu can run into interactive
mode to ask for user input, which will cause jenkins jobs to
hang indefinitely.

This patch set environmental variable DEBIAN_FRONTEND to
noninteractive to force ubuntu to run commands in non-interactive
mode

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
