### PR TITLE
single-node.sh : move $PROVIDER out of $FABTEST_OPTS

### DIFF
--- a/single-node.sh
+++ b/single-node.sh
@@ -33,7 +33,7 @@ ssh-keygen -f ${HOME}/.ssh/id_rsa -N "" > /dev/null
 cat ${HOME}/.ssh/id_rsa.pub >> ${HOME}/.ssh/authorized_keys
 
 # Provider-specific handling of the options passed to runfabtests.sh
-FABTEST_OPTS="-vvv ${EXCLUDE} ${PROVIDER}"
+FABTEST_OPTS="-vvv ${EXCLUDE}"
 case "${PROVIDER}" in
 "efa")
     # EFA provider supports a custom address format based on the GID of the
@@ -50,7 +50,7 @@ case "${PROVIDER}" in
     ;;
 esac
 
-${HOME}/libfabric/fabtests/install/bin/runfabtests.sh ${FABTEST_OPTS} 127.0.0.1 127.0.0.1
+${HOME}/libfabric/fabtests/install/bin/runfabtests.sh ${FABTEST_OPTS} ${PROVIDER} 127.0.0.1 127.0.0.1
 
 EOF
 


### PR DESCRIPTION
Currently, single-node.sh has $PROVIDER in $FABTEST_OPTS,
then append more options to it, which confuses runfabtests.sh.
Because the syntax of that script is:

    runfabtests.sh $FABTEST_OPTS $PROVIDER $SERVER_IP $CLIENT_IP.

This patch take PROVIDER out of FABTEST_OPTS, and put it in
command line right after $FABTEST_OPTS.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
