### PR TITLE
single-node.sh : use bash -c to run fabtests

### DIFF
--- a/single-node.sh
+++ b/single-node.sh
@@ -50,7 +50,7 @@ case "${PROVIDER}" in
     ;;
 esac
 
-${HOME}/libfabric/fabtests/install/bin/runfabtests.sh ${FABTEST_OPTS} ${PROVIDER} 127.0.0.1 127.0.0.1
+bash -c "${HOME}/libfabric/fabtests/install/bin/runfabtests.sh ${FABTEST_OPTS} ${PROVIDER} 127.0.0.1 127.0.0.1"
 
 EOF
 


### PR DESCRIPTION
Bash will automatically add single quotes around strings when running
commands, which convert one arugment "-P 0" to two arguments:
 '"-P' and '0"'.

To avoid this, this patch use bash -c to run the command.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
