### PR TITLE
Change the way EFA GID was obtained

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -46,7 +46,7 @@ runfabtests_script_builder()
     fi
     if [ ${PROVIDER} == "efa" ];then
         gid_c=$4
-        gid_s=$(cat /sys/class/infiniband/efa_0/ports/1/gids/0)
+        gid_s=$(ibv_devinfo -v | grep GID | awk '{print $3}')
         ${HOME}/libfabric/fabtests/install/bin/runfabtests.sh -vvv -t all -C "-P 0" -s $gid_s -c $gid_c ${EXCLUDE} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}
     else
         ${HOME}/libfabric/fabtests/install/bin/runfabtests.sh -vvv ${EXCLUDE} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}
@@ -58,7 +58,7 @@ EOF
 execute_runfabtests()
 {
     if [ ${PROVIDER} == "efa" ];then
-        gid_c=$(ssh -o StrictHostKeyChecking=no -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[$1]} cat /sys/class/infiniband/efa_0/ports/1/gids/0)
+        gid_c=$(ssh -o StrictHostKeyChecking=no -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[$1]} ibv_devinfo -v | grep GID | awk '{print $3}')
     else
         gid_c=""
     fi

--- a/single-node.sh
+++ b/single-node.sh
@@ -39,7 +39,7 @@ case "${PROVIDER}" in
     # EFA provider supports a custom address format based on the GID of the
     # device. Extract that from sysfs and pass it to the tests. Also have the
     # client communicate with QP0 of the server.
-    gid=$(cat /sys/class/infiniband/efa_0/ports/1/gids/0)
+    gid=$(ibv_devinfo -v | grep GID | awk '{print $3}')
     FABTEST_OPTS+=" -t all -C \"-P 0\" -s $gid -c $gid"
     ;;
 "shm")


### PR DESCRIPTION
Currently, EFA GID was obtained from the following file

        /sys/class/infiniband/efa_0/ports/1/gids/0

This method will not work after we switch to rdma-core 27.0
in EFA installer 1.8.0, because rdma-core 27.0 will rename the
device efa_0 to rdmap0s6.

This patch extract GID from the output of
    "/opt/amazon/efa/bin/fi_info -p efa"
which would work with rdma-core 27.0.
The full path to fi_info is needed because ubuntu will not
source /etc/profile.d/efa.sh for non-interactive shell.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
