### PR TITLE
Install and test Intel MPI 2019U6 and add reboot

### DIFF
--- a/install-impi.sh
+++ b/install-impi.sh
@@ -1,4 +1,5 @@
-curl -O http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15553/aws_impi.sh
-chmod 755 aws_impi.sh
-./aws_impi.sh install
-echo "export IMPI_ENV=/opt/intel/impi/2019.4.243/intel64/bin/mpivars.sh" >> ~/.bash_profile
+curl -O http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/16120/l_mpi_2019.6.166.tgz
+tar -zxf l_mpi_2019.6.166.tgz
+cd l_mpi_2019.6.166
+sed -e "s/decline/accept/" silent.cfg > accept.cfg
+sudo ./install.sh -s accept.cfg

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -27,7 +27,7 @@ function ompi_setup {
 }
 
 function impi_setup {
-    source $IMPI_ENV
+    source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
     export I_MPI_DEBUG=1
     export MPI_ARGS=""
 }

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -110,6 +110,17 @@ for IP in ${INSTANCE_IPS[@]}; do
 done
 wait
 
+if [ ${REBOOT_AFTER_INSTALL} -eq 1 ]; then
+    for IP in ${INSTANCE_IPS[@]}; do
+        ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${IP} \
+            "sudo reboot" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'$IP' \1/'
+    done
+
+    for IP in ${INSTANCE_IPS[@]}; do
+        test_ssh ${IP}
+    done
+fi
+
 # Prepare runfabtests script to be run on the server (INSTANCE_IPS[0])
 runfabtests_script_builder
 


### PR DESCRIPTION
This patch replace Intel MPI 2019U4 with Intel MPI 2019U6,
also add a reboot step

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
