### PR TITLE
Adjust pushd and popd calls

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -418,7 +418,6 @@ parse_txt_junit_xml()
 {
     exit_code=$?
     set +x
-    pushd ${output_dir}
     get_rft_yaml_to_junit_xml
     # Read all .txt files
     for file in *.txt; do
@@ -457,7 +456,6 @@ parse_txt_junit_xml()
         done < ${file}
         junit_xml ${file_name}
     done
-    popd
     set -x
 }
 
@@ -483,8 +481,8 @@ parse_fabtests()
         fi
         line_no=$((${line_no}+1))
     done < $1
-    junit_xml ${file_name}
     popd
+    junit_xml ${file_name}
 }
 
 # It updates the filename in rft_yaml_to_junit_xml on the fly to the file_name


### PR DESCRIPTION
Currently function parse_txt_junit_xml() calls
     pushd ${output_dir}
at the beginning, and calls popd at the end.
This is causing issues because all functions it calls:

       get_rft_yaml_to_junit_xml(),
       parse_fabtests()
       junit_xml()

Also does pushd and popd, which shows some error message.

This patch remove pushd and popd call from parse_txt_junit_xml().
Also adjust the sequency of calls in parse_fabtests() for the same
reason.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
