### PR TITLE
Special treatment of libfabric v1.8.x branch

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -223,6 +223,8 @@ script_builder()
     ${label}_install_deps
     if [ -n "$LIBFABRIC_INSTALL_PATH" ]; then
         echo "LIBFABRIC_INSTALL_PATH=$LIBFABRIC_INSTALL_PATH" >> ${tmp_script}
+    elif [ ${TARGET_BRANCH} == "v1.8.x" ]; then
+        cat install-libfabric-1.8.sh >> ${tmp_script}
     else
         cat install-libfabric.sh >> ${tmp_script}
     fi
@@ -337,7 +339,11 @@ test_ssh()
 efa_software_components()
 {
     if [ -z "$EFA_INSTALLER_URL" ]; then
-        EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz"
+        if [ ${TARGET_BRANCH} == "v1.8.x" ]; then
+            EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.7.1.tar.gz"
+        else
+            EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz"
+        fi
     fi
     echo "curl -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}
     cat <<-"EOF" >> ${tmp_script}

--- a/install-libfabric-1.8.sh
+++ b/install-libfabric-1.8.sh
@@ -1,0 +1,20 @@
+echo "==> Building libfabric 1.8.x"
+cd ${HOME}
+git clone https://github.com/ofiwg/libfabric
+cd ${HOME}/libfabric
+git fetch origin +refs/pull/$PULL_REQUEST_ID/*:refs/remotes/origin/pr/$PULL_REQUEST_ID/*
+git checkout $PULL_REQUEST_REF -b PRBranch
+./autogen.sh
+./configure --prefix=${HOME}/libfabric/install/ \
+    --enable-debug  \
+    --enable-mrail  \
+    --enable-tcp    \
+    --enable-rxm    \
+    --disable-rxd   \
+    --disable-verbs
+make -j 4
+make install
+LIBFABRIC_INSTALL_PATH=${HOME}/libfabric/install
+# ld.so.conf.d files are preferred in alphabetical order
+# this doesn't seem to be working for non-interactive shells
+sudo bash -c "echo ${LIBFABRIC_INSTALL_PATH} > /etc/ld.so.conf.d/aaaa-libfabric-testing.sh"


### PR DESCRIPTION
The Latest EFA Installer installs the Open MPI built with libfabric
1.9, which will not work with the v1.8.x branch.

This patch check the pull request's source code version, and use
EFA Installer 1.7.1 for if the source code is 1.8.x, and also will
not build rdma-core v27 for it

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
