### PR TITLE
Add mpirun path and --version string to the ouptut file generated

### DIFF
--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -37,6 +37,7 @@ for host in $hosts; do
     scp -r ${osu_dir} $host:/tmp
 done
 
+echo "$mpirun_cmd --version"
 $mpirun_cmd --version
 
 # TODO: split this output so that it shows up as three separate tests in the xml output


### PR DESCRIPTION
The output file generated for mpi, does not contain the executed
commands. Echo the path with --version to indicate version string

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
