### PR TITLE
Revert shellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,5 @@ before_install:
 script:
 - bashate -i E006 *.sh
 - bashate nccl/*/*.sh
-- shellcheck -S error *.sh
+- # Commenting out shell-check till we fully resolve existing warnings
+- # shellcheck -S warning *.sh

--- a/common.sh
+++ b/common.sh
@@ -129,7 +129,7 @@ create_instance()
     fi
     echo "==> Creating instances"
     while [ ${error} -ne 0 ] && [ ${create_instance_count} -lt 30 ]; do
-        for subnet in "${subnet_ids[@]}"; do
+        for subnet in ${subnet_ids[@]}; do
             error=1
             set +e
             INSTANCE_IDS=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 run-instances \
@@ -150,7 +150,7 @@ create_instance()
             if [ $create_instance_exit_code -ne 0 ]; then
                 # If the error was due to SERVER_ERROR, set error=1 else for
                 # some other error set error=0
-                for code in "${SERVER_ERROR[@]}"; do
+                for code in ${SERVER_ERROR[@]}; do
                     if [[ "${INSTANCE_IDS}" == *${code}* ]]; then
                         error=1
                         break
@@ -182,7 +182,7 @@ test_instance_status()
 get_instance_ip()
 {
     execution_seq=$((${execution_seq}+1))
-    INSTANCE_IPS=$(aws ec2 describe-instances --instance-ids "${INSTANCE_IDS[@]}" \
+    INSTANCE_IPS=$(aws ec2 describe-instances --instance-ids ${INSTANCE_IDS[@]} \
                         --query "Reservations[*].Instances[*].PrivateIpAddress" \
                         --output=text)
 }
@@ -526,9 +526,9 @@ EOF
 terminate_instances()
 {
     # Terminates slave node
-    if [[ ! -z ${INSTANCE_IDS[*]} ]]; then
-        AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids "${INSTANCE_IDS[@]}"
-        AWS_DEFAULT_REGION=us-west-2 aws ec2 wait instance-terminated --instance-ids "${INSTANCE_IDS[@]}"
+    if [[ ! -z ${INSTANCE_IDS[@]} ]]; then
+        AWS_DEFAULT_REGION=us-west-2 aws ec2 terminate-instances --instance-ids ${INSTANCE_IDS[@]}
+        AWS_DEFAULT_REGION=us-west-2 aws ec2 wait instance-terminated --instance-ids ${INSTANCE_IDS[@]}
     fi
 }
 

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -82,7 +82,7 @@ INSTANCE_IDS=($INSTANCE_IDS)
 
 execution_seq=$((${execution_seq}+1))
 # Wait until all instances have passed status check
-for ID in "${INSTANCE_IDS[@]}"; do
+for ID in ${INSTANCE_IDS[@]}; do
     test_instance_status "$ID" &
 done
 wait
@@ -108,18 +108,18 @@ set -x
 
 execution_seq=$((${execution_seq}+1))
 # SSH into nodes and install libfabric concurrently on all nodes
-for IP in "${INSTANCE_IPS[@]}"; do
+for IP in ${INSTANCE_IPS[@]}; do
     install_libfabric "$IP" &
 done
 wait
 
 if [ ${REBOOT_AFTER_INSTALL} -eq 1 ]; then
-    for IP in "${INSTANCE_IPS[@]}"; do
+    for IP in ${INSTANCE_IPS[@]}; do
         ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${IP} \
             "sudo reboot" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'$IP' \1/'
     done
 
-    for IP in "${INSTANCE_IPS[@]}"; do
+    for IP in ${INSTANCE_IPS[@]}; do
         test_ssh ${IP}
     done
 fi
@@ -136,7 +136,7 @@ test_list="impi"
 for mpi in $test_list; do
     execution_seq=$((${execution_seq}+1))
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-        bash mpi_ring_c_test.sh ${mpi} "${INSTANCE_IPS[@]}" | tee ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
+        bash mpi_ring_c_test.sh ${mpi} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
 
     set +e
     grep -q "Test Passed" ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
@@ -147,7 +147,7 @@ for mpi in $test_list; do
     set -e
 
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-        bash mpi_osu_test.sh ${mpi} "${INSTANCE_IPS[@]}" | tee ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt
+        bash mpi_osu_test.sh ${mpi} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt
 
     set +e
     grep -q "Test Passed" ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -80,7 +80,7 @@ INSTANCE_IDS=($INSTANCE_IDS)
 
 execution_seq=$((${execution_seq}+1))
 # Wait until all instances have passed status check
-for ID in "${INSTANCE_IDS[@]}"; do
+for ID in ${INSTANCE_IDS[@]}; do
     test_instance_status "$ID" &
 done
 wait
@@ -106,18 +106,18 @@ set -x
 
 execution_seq=$((${execution_seq}+1))
 # SSH into nodes and install libfabric concurrently on all nodes
-for IP in "${INSTANCE_IPS[@]}"; do
+for IP in ${INSTANCE_IPS[@]}; do
     install_libfabric "$IP" &
 done
 wait
 
 if [ ${REBOOT_AFTER_INSTALL} -eq 1 ]; then
-    for IP in "${INSTANCE_IPS[@]}"; do
+    for IP in ${INSTANCE_IPS[@]}; do
         ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${IP} \
             "sudo reboot" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'$IP' \1/'
     done
 
-    for IP in "${INSTANCE_IPS[@]}"; do
+    for IP in ${INSTANCE_IPS[@]}; do
         test_ssh ${IP}
     done
 fi
@@ -153,7 +153,7 @@ if [ ${PROVIDER} == "efa" ]; then
     for mpi in $test_list; do
         execution_seq=$((${execution_seq}+1))
         ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-            bash mpi_ring_c_test.sh ${mpi} ${libfabric_job_type} "${INSTANCE_IPS[@]}" | tee ${output_dir}/temp_execute_ring_c_${mpi}.txt
+            bash mpi_ring_c_test.sh ${mpi} ${libfabric_job_type} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_ring_c_${mpi}.txt
 
         set +e
         grep -q "Test Passed" ${output_dir}/temp_execute_ring_c_${mpi}.txt
@@ -164,7 +164,7 @@ if [ ${PROVIDER} == "efa" ]; then
         set -e
 
         ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-            bash mpi_osu_test.sh ${mpi} ${libfabric_job_type} "${INSTANCE_IPS[@]}" | tee ${output_dir}/temp_execute_osu_${mpi}.txt
+            bash mpi_osu_test.sh ${mpi} ${libfabric_job_type} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_osu_${mpi}.txt
 
         set +e
         grep -q "Test Passed" ${output_dir}/temp_execute_osu_${mpi}.txt


### PR DESCRIPTION
The use of bashmaps would have to be reworked a bit to keep shellcheck happy, just adding the quotes would not sufffice. Reverting that change to get Libfabric CI jobs to pass while I write up a fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
