### PR TITLE
Add custom wait instance and image functions and Increase timeout for all_reduce_perf to 30 minutes

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -433,7 +433,7 @@ EOF
     echo "==>The number of GPUs is: $NUM_GPUS"
 
     set -xe
-    timeout 20m $HOME/anaconda3/bin/mpirun \
+    timeout 30m $HOME/anaconda3/bin/mpirun \
         -x FI_PROVIDER="$PROVIDER" \
         -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
         -x NCCL_ALGO=ring --hostfile $HOME/hosts \


### PR DESCRIPTION
nccl all_reduce_perf test required more time to complete for tcp
provider.

Signed-off-by: Oleksandr Zubenko zubeno@amazon.com

*Issue #, if available:*

*Description of changes:*
This PR will add custom wait instance and image functions
the reason is because default aws cli commands:
 - aws ec2 wait image-available
 - aws ec2 wait instance-status-ok 
Have limited 10 mins of waiting time. 
For large instances and images it requires more than that. 
Custom functions have customizable waiting time.

Additionally the timeout for all_reduce_perf will be increased to 30 minutes.
NCCL all_reduce_perf test required more time to complete for tcp provider.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
