### PR TITLE
Mark build unstable if instance does not come up

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -164,7 +164,9 @@ create_instance()
             # If run-instances wasn't successful, and it was due to some other
             # error, exit and fail the test.
             if [ ${error} -eq 0 ]; then
-                exit ${create_instance_exit_code}
+                # Mark build as unstable, error code 65 has been used to
+                # identify unstable build
+                exit 65
             fi
         done
         sleep 2m
@@ -175,7 +177,7 @@ create_instance()
 # Holds testing every 15 seconds for 40 attempts until the instance status check is ok
 test_instance_status()
 {
-    aws ec2 wait instance-status-ok --instance-ids $1
+    aws ec2 wait instance-status-ok --instance-ids $1 || exit 65
 }
 
 # Get IP address for instances
@@ -536,6 +538,7 @@ terminate_instances()
 
 on_exit()
 {
+    return_code=$?
     set +e
     # Some of the commands run are background procs, wait for them.
     wait
@@ -547,6 +550,7 @@ on_exit()
     # group. Add a small delay as a workaround.
     sleep 1
     delete_pg
+    return $return_code
 }
 
 exit_status()

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -76,7 +76,7 @@ install_libfabric()
 }
 
 set +x
-create_instance || { echo "==>Unable to create instance"; exit 1; }
+create_instance || { echo "==>Unable to create instance"; exit 65; }
 set -x
 INSTANCE_IDS=($INSTANCE_IDS)
 

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -74,7 +74,7 @@ execute_runfabtests()
 }
 
 set +x
-create_instance || { echo "==>Unable to create instance"; exit 1; }
+create_instance || { echo "==>Unable to create instance"; exit 65; }
 set -x
 INSTANCE_IDS=($INSTANCE_IDS)
 

--- a/single-node.sh
+++ b/single-node.sh
@@ -11,7 +11,7 @@ NODES=1
 export ENABLE_PLACEMENT_GROUP=0
 
 set +x
-create_instance || { echo "==>Unable to create instance"; exit 1; }
+create_instance || { echo "==>Unable to create instance"; exit 65; }
 set -x
 
 execution_seq=$((${execution_seq}+1))


### PR DESCRIPTION
Return code 65, to indicate UNSTABLE build only when run_instances
fail or when the instance fails status-check.

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
