### PR TITLE
Add sleep after creating placement group

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -75,6 +75,7 @@ create_pg()
     AWS_DEFAULT_REGION=us-west-2 aws ec2 create-placement-group \
         --group-name ${PLACEMENT_GROUP} \
         --strategy cluster
+    sleep 1
     return $?
 }
 


### PR DESCRIPTION
On centos and rhel, the placement group takes some time to come up.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
