### PR TITLE
remove us-east-1c from nccl/common/nccl-common.sh region list

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -121,7 +121,7 @@ define_subnets() {
                         --query "Subnets[*].SubnetId" --output=text)
     elif [[ "${AWS_DEFAULT_REGION}" == 'us-east-1' ]]; then
         subnet_ids=$(aws ec2 describe-subnets \
-            --filters "Name=availability-zone,Values=[us-east-1a,us-east-1b,us-east-1c,us-east-1d,us-east-1f]" \
+            --filters "Name=availability-zone,Values=[us-east-1a,us-east-1b,us-east-1d,us-east-1f]" \
                         "Name=vpc-id,Values=$vpc_id" \
                         --query "Subnets[*].SubnetId" --output=text)
     else


### PR DESCRIPTION
nccl test requre p3dn.24xlarge instance, which is not available
by us-east-1c region. This patch remove that region from region
list.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
