### PR TITLE
Run fabtest on Ubuntu twice

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -216,12 +216,6 @@ script_builder()
         efa_software_components
     fi
 
-    # Ubuntu disallows non-child process ptrace by default, which is
-    # required for the use of CMA in the shared-memory codepath.
-    if [ ${label} == "ubuntu" ];then
-        echo "sudo sysctl -w kernel.yama.ptrace_scope=0" >> ${tmp_script}
-    fi
-
     ${label}_install_deps
     if [ -n "$LIBFABRIC_INSTALL_PATH" ]; then
         echo "LIBFABRIC_INSTALL_PATH=$LIBFABRIC_INSTALL_PATH" >> ${tmp_script}

--- a/single-node.sh
+++ b/single-node.sh
@@ -54,6 +54,15 @@ bash -c "${HOME}/libfabric/fabtests/install/bin/runfabtests.sh ${FABTEST_OPTS} $
 
 EOF
 
+if [ ${label} == "ubuntu" ];then
+    echo "sudo sysctl -w kernel.yama.ptrace_scope=0" >> ${tmp_script}
+    cat <<-"EOF" >> ${tmp_script}
+# Turn off ptrace protection, run fabtest again to test CMA code path
+bash -c "${HOME}/libfabric/fabtests/install/bin/runfabtests.sh ${FABTEST_OPTS} ${PROVIDER} 127.0.0.1 127.0.0.1"
+
+EOF
+fi
+
 # Test whether node is ready for SSH connection or not
 test_ssh ${INSTANCE_IPS}
 


### PR DESCRIPTION
First run with ptrace protection to test non-CMA path,
Second run without ptrace protection to test CMA path.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>
