### PR TITLE
Revert "Turn on ptrace protection"

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -216,6 +216,12 @@ script_builder()
         efa_software_components
     fi
 
+    # Ubuntu disallows non-child process ptrace by default, which is
+    # required for the use of CMA in the shared-memory codepath.
+    if [ ${label} == "ubuntu" ];then
+        echo "sudo sysctl -w kernel.yama.ptrace_scope=0" >> ${tmp_script}
+    fi
+
     ${label}_install_deps
     if [ -n "$LIBFABRIC_INSTALL_PATH" ]; then
         echo "LIBFABRIC_INSTALL_PATH=$LIBFABRIC_INSTALL_PATH" >> ${tmp_script}


### PR DESCRIPTION
This reverts commit 681a780c9701bb01df19307bc84a1aa70175a9cc,
which was merged to test the following PR:

    https://github.com/ofiwg/libfabric/pull/5682

and will cause any other PR to fail. Therefore we revert it
until 5682 is merged.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
