### PR TITLE
Lock NCCL version on 2.5.7-1 to fix make issue in aws-ofi-nccl

### DIFF
--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -29,6 +29,9 @@ if [[ ${TARGET_REPO} == 'ofiwg/libfabric' ]];then
     fi
 fi
 
+# Locking NCCL version to 2.5.7-1
+NCCL_2_5_7='3701130b3c1bcdb01c14b3cb70fe52498c1e82b7'
+
 # Identify latest CUDA on server
 latest_cuda=$(find /usr/local -maxdepth 1 -type d -iname "cuda*" | sort -V -r | head -1)
 echo "==> Latest CUDA: ${latest_cuda}"
@@ -125,6 +128,7 @@ install_nccl() {
     cd $HOME
     sudo rm -rf nccl
     sudo git clone https://github.com/NVIDIA/nccl.git && cd nccl
+    sudo git checkout ${NCCL_2_5_7}
     sudo make -j src.build CUDA_HOME=${latest_cuda}
 }
 


### PR DESCRIPTION
In order to fix make execution which started to fail after NCCL PR: https://github.com/NVIDIA/nccl/commit/533e3702cf713a9ab9a634fbb8b4c380ecf381e6 

Locking NCCL on 2.5.7 version.

Signed-off-by: Oleksandr Zubenko <zubeno@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
