### PR TITLE
squelch grep return code for -b option

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -46,7 +46,7 @@ runfabtests_script_builder()
         EXCLUDE=""
     fi
     runfabtests_script="${HOME}/libfabric/fabtests/install/bin/runfabtests.sh"
-    b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b')"
+    b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b' || true)"
     FABTESTS_OPTS="-E LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\" -vvv ${EXCLUDE}"
     if [ ${PROVIDER} == "efa" ]; then
         if [ -n "$b_option_available" ]; then
@@ -57,7 +57,7 @@ runfabtests_script_builder()
             FABTESTS_OPTS+=" -C \"-P 0\" -s $gid_s -c $gid_c -t all"
         fi
     fi
-    $runfabtests_script ${FABTESTS_OPTS} ${EXCLUDE} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}
+    bash -c "$runfabtests_script ${FABTESTS_OPTS} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}"
 EOF
 }
 

--- a/single-node.sh
+++ b/single-node.sh
@@ -43,7 +43,7 @@ case "${PROVIDER}" in
     # client communicate with QP0 of the server. This is only for older
     # versions of fabtests, newer versions can use the -b option to exchange
     # out of band.
-    b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b')"
+    b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b' || true)"
     FABTESTS_OPTS+=" -t all"
     if [ -n "$b_option_available" ]; then
         FABTESTS_OPTS+=" -b"


### PR DESCRIPTION
Adding the -b option broke the script as 'set -e' is enabled. We should
remove that but that fix is for another day. Also make the single
node/multi node fabtest run the same for consistency and quote escaping
and remove extra parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
