### PR TITLE
Do not install valgrind-devel package

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -251,7 +251,7 @@ EOF
 alinux_install_deps() {
     cat <<-"EOF" >> ${tmp_script}
     sudo yum -y groupinstall 'Development Tools'
-    sudo yum -y install cmake gcc libnl3-devel libudev-devel make pkgconfig valgrind-devel
+    sudo yum -y install cmake gcc libnl3-devel libudev-devel make pkgconfig
 EOF
 }
 
@@ -270,7 +270,7 @@ rhel_install_deps() {
     # An update after enabling the rhui optional repository seems to be needed
     # to refresh the CA certs.
     sudo yum update -y
-    sudo yum -y install cmake gcc libnl3-devel libudev-devel make pkgconfig valgrind-devel
+    sudo yum -y install cmake gcc libnl3-devel libudev-devel make pkgconfig
 EOF
 }
 
@@ -283,7 +283,7 @@ centos_update()
 centos_install_deps() {
     cat <<-"EOF" >> ${tmp_script}
     sudo yum -y groupinstall 'Development Tools'
-    sudo yum -y install cmake gcc libnl3-devel libudev-devel make pkgconfig valgrind-devel
+    sudo yum -y install cmake gcc libnl3-devel libudev-devel make pkgconfig
 EOF
 }
 


### PR DESCRIPTION
valgrind-devel is not used by the test and is causing troubles on
RHEL 7.7 and RHEL 7.6

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
