### PR TITLE
Fix minimal test, add print for huge pages

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -347,6 +347,7 @@ efa_software_components()
     cd ${HOME}/aws-efa-installer
     sudo ./efa_installer.sh -y
     . /etc/profile.d/efa.sh
+    echo "huge pages: $(cat /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages)"
 EOF
 }
 

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -35,7 +35,6 @@ efa_software_components_minimal()
     echo "tar -xf efa-installer.tar.gz" >> ${tmp_script}
     echo "cd \${HOME}/aws-efa-installer" >> ${tmp_script}
     echo "sudo ./efa_installer.sh -m -y" >> ${tmp_script}
-    echo ". /etc/profile.d/efa.sh" >> ${tmp_script}
 }
 
 multi_node_efa_minimal_script_builder()


### PR DESCRIPTION
Fix an issue with the minimal test install and add a print to display the number of huge pages allocated after the installer runs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
