### PR TITLE
Disable nccl testing on ubuntu

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -6,6 +6,9 @@
 
 set -e
 
+if [[ "${label}" == 'ubuntu' ]]; then
+    exit 0
+fi
 # Unique id for groups and ami creation
 UUID=$(uuidgen)
 


### PR DESCRIPTION
Disable nccl single node and nccl multi-node test on ubuntu
Multiple PRs have failed due to an issue with nccl test
on ubuntu.

https://libfabric-ci.aws.a2z.com/job/libfabric-ci-pipeline/192/
https://libfabric-ci.aws.a2z.com/job/libfabric-ci-pipeline/193/

Once the issue is fixed, this commit can be reverted

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
