### PR TITLE
Change instance creation logic for nccl scripts

### DIFF
--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -207,8 +207,6 @@ install_software() {
         install_aws_ofi_nccl_plugin
         install_nccl_tests
     fi
-
-
 }
 
 case $PLATFORM_ID in


### PR DESCRIPTION
This PR includes the following changes:
Add common instance creation function for ami and test stage
Eliminate AZs without p3dn capacity
Identify and recreate instances in case of termination
Copy custom ami to all regions
Generate separate uuid for each invocation
Terminate all resources after test is done

Signed-off-by: Oleksandr Zubenko <zubeno@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
