### PR TITLE
Bug fix: add missing $libfabric_job_type parameter in multi-node-efa-minimal.sh

### DIFF
--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -135,7 +135,7 @@ test_list="impi"
 for mpi in $test_list; do
     execution_seq=$((${execution_seq}+1))
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-        bash mpi_ring_c_test.sh ${mpi} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
+        bash mpi_ring_c_test.sh ${mpi} ${libfabric_job_type} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
 
     set +e
     grep -q "Test Passed" ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
@@ -146,7 +146,7 @@ for mpi in $test_list; do
     set -e
 
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-        bash mpi_osu_test.sh ${mpi} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt
+        bash mpi_osu_test.sh ${mpi} ${libfabric_job_type} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt
 
     set +e
     grep -q "Test Passed" ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt


### PR DESCRIPTION
Add missing $libfabric_job_type parameter when executing mpi_ring_c_test.sh and mpi_osu_test.sh scripts in multi-node-efa-minimal.sh

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
