### PR TITLE
Turn off ptrace on Ubuntu when testing v1.9.x and v1.8.x branch

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -225,6 +225,17 @@ script_builder()
         efa_software_components
     fi
 
+    # The libfabric shm provider use CMA for communication. By default ubuntu
+    # disallows non-child process ptrace by, which disable CMA.
+    # Since libfabric 1.10, shm provider has a fallback solution, which will
+    # be used when CMA is not available. Therefore, we turn off ptrace protection
+    # for v1.9.x and v1.8.x
+    if [ ${label} == "ubuntu" ]; then
+        if [ ${TARGET_BRANCH} == "v1.9.x" ] || [ ${TARGET_BRANCH} == "v1.8.x" ];then
+            echo "sudo sysctl -w kernel.yama.ptrace_scope=0" >> ${tmp_script}
+        fi
+    fi
+
     ${label}_install_deps
     if [ -n "$LIBFABRIC_INSTALL_PATH" ]; then
         echo "LIBFABRIC_INSTALL_PATH=$LIBFABRIC_INSTALL_PATH" >> ${tmp_script}


### PR DESCRIPTION
The libfabric shm provider use CMA for communication. By default ubuntu
disallows non-child process ptrace by, which disable CMA.
Since libfabric 1.10, shm provider has a fallback solution, which will
be used when CMA is not available. Therefore, we turn off ptrace protection
for v1.9.x and v1.8.x

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
