### PR TITLE
Fix subnet id

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -125,7 +125,7 @@ define_subnets() {
             --query "Subnets[*].SubnetId" --output=text)
     elif [[ "${AWS_DEFAULT_REGION}" == 'us-east-1' ]]; then
         subnet_ids=$(aws ec2 describe-subnets \
-            --filters "Name=availability-zone,Values=[us-east-1a,us-east-1d]" \
+            --filters "Name=availability-zone,Values=[us-east-1a,us-east-1b]" \
             "Name=vpc-id,Values=$vpc_id" \
             --query "Subnets[*].SubnetId" --output=text)
     else


### PR DESCRIPTION
p3dn.24xlarge is not supported in us-east-1d, its supported in
us-east-1a and us-east-1b

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
