### PR TITLE
Use openmpi instead of anaconda and enable RDMAV_FORK_SAFE

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -492,21 +492,21 @@ EOF
 
         echo "==> Running nccl_connection unit test"
         set -xe
-        timeout 5m $HOME/anaconda3/bin/mpirun -n 2 \
+        timeout 5m /opt/amazon/openmpi/bin/mpirun -n 2 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
             --mca btl tcp,self --mca btl_tcp_if_exclude  lo,docker0 \
             --bind-to none ~/aws-ofi-nccl/install/bin/nccl_connection
 
         echo "==> Running ring unit test"
-        timeout 5m $HOME/anaconda3/bin/mpirun -n 3 \
+        timeout 5m /opt/amazon/openmpi/bin/mpirun -n 3 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
             --mca btl tcp,self --mca btl_tcp_if_exclude  lo,docker0 \
             --bind-to none ~/aws-ofi-nccl/install/bin/ring
 
         echo "==> Running nccl_message_transfer unit test"
-        timeout 5m $HOME/anaconda3/bin/mpirun -n 2 \
+        timeout 5m /opt/amazon/openmpi/bin/mpirun -n 2 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
             --mca btl tcp,self --mca btl_tcp_if_exclude  lo,docker0 \
@@ -532,21 +532,21 @@ EOF
 
         echo "==> Running nccl_connection unit test"
         set -xe
-        timeout 5m $HOME/anaconda3/bin/mpirun -n 2 -N 1 \
+        timeout 5m /opt/amazon/openmpi/bin/mpirun -n 2 -N 1 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
             --bind-to none --tag-output --hostfile hosts ~/aws-ofi-nccl/install/bin/nccl_connection
 
         echo "==> Running ring unit test"
-        timeout 5m $HOME/anaconda3/bin/mpirun -n 3 -N 1 \
+        timeout 5m /opt/amazon/openmpi/bin/mpirun -n 3 -N 1 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
             --bind-to none --tag-output --hostfile hosts ~/aws-ofi-nccl/install/bin/ring
 
         echo "==> Running nccl_message_transfer unit test"
-        timeout 5m $HOME/anaconda3/bin/mpirun -n 2 -N 1 \
+        timeout 5m /opt/amazon/openmpi/bin/mpirun -n 2 -N 1 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
@@ -572,7 +572,7 @@ EOF
     echo "==>The number of GPUs is: $NUM_GPUS"
 
     set -xe
-    timeout 30m $HOME/anaconda3/bin/mpirun \
+    timeout 30m /opt/amazon/openmpi/bin/mpirun \
         -x FI_PROVIDER="$PROVIDER" \
         -x LD_LIBRARY_PATH="${custom_ld_library_path}" \
         -x NCCL_ALGO=ring --hostfile $HOME/hosts \

--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -578,6 +578,7 @@ EOF
         -x NCCL_ALGO=ring --hostfile $HOME/hosts \
         -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
         -x FI_EFA_TX_MIN_CREDITS=64 \
+        -x RDMAV_FORK_SAFE=1 \
         -x NCCL_DEBUG=INFO \
         -n $NUM_GPUS -N 8 \
         --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -220,8 +220,12 @@ case $PLATFORM_ID in
         install_software
         ;;
     ubuntu)
-        # Wait for initialization to complete
-        sleep 100
+        # Wait until lock /var/lib/dpkg/lock-frontend released
+        sleep 300
+        # Building aws-ofi-nccl plugin with openmpi throws the following error:
+        # /usr/bin/ld: cannot find -ludev
+        # Installing libudev-dev mitigates the issue
+        sudo apt-get install -y libudev-dev
         install_software
         ;;
     *)

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -141,14 +141,14 @@ install_nccl_tests() {
     sudo rm -rf nccl-tests
     git clone https://github.com/NVIDIA/nccl-tests.git && cd nccl-tests
     git checkout ${NCCL_TEST_COMMIT}
-    make MPI=1 MPI_HOME=$HOME/anaconda3 NCCL_HOME=$HOME/nccl/build CUDA_HOME=${latest_cuda}
+    make MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME=$HOME/nccl/build CUDA_HOME=${latest_cuda}
 }
 
 install_aws_ofi_nccl_plugin() {
     cd $HOME/aws-ofi-nccl
     ./autogen.sh
     ./configure --prefix=$HOME/aws-ofi-nccl/install \
-                --with-mpi=$HOME/anaconda3 \
+                --with-mpi=/opt/amazon/openmpi \
                 --with-libfabric=$HOME/libfabric/install \
                 --with-nccl=$HOME/nccl/build \
                 --with-cuda=${latest_cuda}


### PR DESCRIPTION
Install missing libudev-dev dependency

In order to use openmpi we should install additional dependency
Building aws-ofi-nccl plugin with openmpi throws the following error:
/usr/bin/ld: cannot find -ludev
Installing libudev-dev mitigates the issue

Use openmpi instead of anaconda3 for
aws_ofi_nccl_plugin testing

Enable RDMAV_FORK_SAFE
It is required for the libfabric EFA provider to work safely when
fork() is called


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
