### PR TITLE
Add retry for curl/wget

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -2,6 +2,8 @@
 
 execution_seq=1
 BUILD_CODE=0
+CURL_OPT="--retry-connrefused --retry 5"
+WGET_OPT="--retry-connrefused --tries=5"
 output_dir=${output_dir:-$(mktemp -d -p $WORKSPACE)}
 tmp_script=${tmp_script:-$(mktemp -p $WORKSPACE)}
 # Disable IMPI tests for now until apt/yum repo issues are addressed.
@@ -328,6 +330,8 @@ set_var()
     PULL_REQUEST_ID=$1
     PULL_REQUEST_REF=$2
     PROVIDER=$3
+    export CURL_OPT="--retry-connrefused --retry 5"
+    export WGET_OPT="--retry-connrefused --tries=5"
     echo "==>Installing OS specific packages"
 EOF
 }
@@ -361,7 +365,7 @@ efa_software_components()
             EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz"
         fi
     fi
-    echo "curl -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}
+    echo "curl ${CURL_OPT} -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}
     cat <<-"EOF" >> ${tmp_script}
     tar -xf efa-installer.tar.gz
     cd ${HOME}/aws-efa-installer
@@ -399,7 +403,7 @@ get_rft_yaml_to_junit_xml()
 {
     pushd ${output_dir}
     # fabtests junit parser script
-    wget https://raw.githubusercontent.com/ofiwg/libfabric/master/fabtests/scripts/rft_yaml_to_junit_xml
+    wget ${WGET_OPT} https://raw.githubusercontent.com/ofiwg/libfabric/master/fabtests/scripts/rft_yaml_to_junit_xml
     # Add Excluded tag
     sed -i "s,<skipped />,<skipped />\n    EOT\n  when 'Excluded'\n    puts <<-EOT\n    <skipped />,g" rft_yaml_to_junit_xml
     sed -i "s,skipped += 1,skipped += 1\n  when 'Excluded'\n    skipped += 1,g" rft_yaml_to_junit_xml

--- a/efa-check.sh
+++ b/efa-check.sh
@@ -5,7 +5,7 @@
 
 VENDOR_ID="0x1d0f"
 DEV_ID="0xefa0"
-
+CURL_OPT="--retry-connrefused --retry 5"
 usage() {
 cat << EOF
 usage: $(basename "$0") [options]
@@ -77,7 +77,7 @@ echo "======== Instance / Device check ========"
 # Get instance type
 if command -v curl >/dev/null 2>&1; then
     metadata_url="http://169.254.169.254/latest/meta-data/instance-type"
-    echo "Instance type: $(curl -m 1 --retry 3 $metadata_url 2>/dev/null)"
+    echo "Instance type: $(curl -m 1 ${CURL_OPT} $metadata_url 2>/dev/null)"
 fi
 
 # Determine if an EFA device is present and print device list.

--- a/install-impi.sh
+++ b/install-impi.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl --retry 5 -O https://s3.us-west-2.amazonaws.com/subspace-intelmpi/l_mpi_2019.7.217.tgz
+curl ${CURL_OPT} -O https://s3.us-west-2.amazonaws.com/subspace-intelmpi/l_mpi_2019.7.217.tgz
 tar -zxf l_mpi_2019.7.217.tgz
 cd l_mpi_2019.7.217
 sed -e "s/decline/accept/" silent.cfg > accept.cfg

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # MPI helper shell functions
+CURL_OPT="--retry-connrefused --retry 5"
 function check_efa_ompi {
     out=$1
     grep -q "mtl:ofi:prov: efa" $out

--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -13,7 +13,7 @@ hosts=$@
 hostfile=$(mktemp)
 out=$(mktemp)
 
-curl --retry 5 -O http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz
+curl ${CURL_OPT} -O http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz
 osu_dir="osu-micro-benchmarks-5.6.2"
 one_rank_per_node=""
 if [ "${mpi}" == "ompi" ]; then

--- a/mpi_ring_c_test.sh
+++ b/mpi_ring_c_test.sh
@@ -13,7 +13,7 @@ hosts=$@
 hostfile=$(mktemp)
 out=$(mktemp)
 
-curl --retry 5 -O https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_c.c
+curl ${CURL_OPT} -O https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_c.c
 
 if [ "${mpi}" == "ompi" ]; then
     ompi_setup

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -31,7 +31,7 @@ efa_software_components_minimal()
         EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz"
     fi
 
-    echo "curl -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}
+    echo "curl ${CURL_OPT} -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}
     echo "tar -xf efa-installer.tar.gz" >> ${tmp_script}
     echo "cd \${HOME}/aws-efa-installer" >> ${tmp_script}
     echo "sudo ./efa_installer.sh -m -y" >> ${tmp_script}


### PR DESCRIPTION
For wget: default retries is 20 decrease that to 5, add
retry if connection was refused
For curl: retry 5 times with default exponential backoff and
add retry if connection was refused
Retries have been added to reduce the number of failures
in our CI due to errors downloading
Ref: P36056730

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
