### PR TITLE
Remove --retry-connrefused flag from curl/wget

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -2,8 +2,8 @@
 
 execution_seq=1
 BUILD_CODE=0
-CURL_OPT="--retry-connrefused --retry 5"
-WGET_OPT="--retry-connrefused --tries=5"
+CURL_OPT="--retry 5"
+WGET_OPT="--tries=5"
 output_dir=${output_dir:-$(mktemp -d -p $WORKSPACE)}
 tmp_script=${tmp_script:-$(mktemp -p $WORKSPACE)}
 # Disable IMPI tests for now until apt/yum repo issues are addressed.
@@ -330,8 +330,8 @@ set_var()
     PULL_REQUEST_ID=$1
     PULL_REQUEST_REF=$2
     PROVIDER=$3
-    export CURL_OPT="--retry-connrefused --retry 5"
-    export WGET_OPT="--retry-connrefused --tries=5"
+    export CURL_OPT="--retry 5"
+    export WGET_OPT="--tries=5"
     echo "==>Installing OS specific packages"
 EOF
 }

--- a/efa-check.sh
+++ b/efa-check.sh
@@ -5,7 +5,7 @@
 
 VENDOR_ID="0x1d0f"
 DEV_ID="0xefa0"
-CURL_OPT="--retry-connrefused --retry 5"
+CURL_OPT="--retry 5"
 usage() {
 cat << EOF
 usage: $(basename "$0") [options]

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # MPI helper shell functions
-CURL_OPT="--retry-connrefused --retry 5"
+CURL_OPT="--retry 5"
 function check_efa_ompi {
     out=$1
     grep -q "mtl:ofi:prov: efa" $out


### PR DESCRIPTION
--retry-connrefused flag is not recognised on centos
rhel and ubuntu1604. Remove it and allow tests to pass

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
