### PR TITLE
Update EFA_INSTALLER_URL to use cloud front url

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -360,9 +360,9 @@ efa_software_components()
 {
     if [ -z "$EFA_INSTALLER_URL" ]; then
         if [ ${TARGET_BRANCH} == "v1.8.x" ]; then
-            EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-1.7.1.tar.gz"
+            EFA_INSTALLER_URL="https://efa-installer.amazonaws.com/aws-efa-installer-1.7.1.tar.gz"
         else
-            EFA_INSTALLER_URL="https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz"
+            EFA_INSTALLER_URL="https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz"
         fi
     fi
     echo "curl ${CURL_OPT} -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}


### PR DESCRIPTION
This patch update EFA_INSTALLER_URL to make CI test the cloud
front url listed in the manual

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
