### PR TITLE
Do not build rdma-core

### DIFF
--- a/install-libfabric.sh
+++ b/install-libfabric.sh
@@ -1,14 +1,6 @@
 #!/usr/bin/env bash
 
 echo "==> Building libfabric"
-# Build version 27 of rdma-core for EFA
-cd ${HOME}
-git clone -b v27.0 https://github.com/linux-rdma/rdma-core.git
-cd ${HOME}/rdma-core
-./build.sh
-echo "export LD_LIBRARY_PATH=${HOME}/rdma-core/build/lib/:\$LD_LIBRARY_PATH" >> ~/.bash_profile
-echo "export LD_LIBRARY_PATH=${HOME}/rdma-core/build/lib/:\$LD_LIBRARY_PATH" >> ~/.bashrc
-source ~/.bash_profile
 # Pulls the libfabric repository and checks out the pull request commit
 cd ${HOME}
 git clone https://github.com/ofiwg/libfabric
@@ -25,7 +17,7 @@ fi
     --enable-rxm    \
     --disable-rxd   \
     --disable-verbs \
-    --enable-efa=${HOME}/rdma-core/build
+    --enable-efa
 make -j 4
 make install
 LIBFABRIC_INSTALL_PATH=${HOME}/libfabric/install


### PR DESCRIPTION
The ofiwg/libfabric master and 1.10.x branch require rdma-core >=27.0
to build. Current code will checkout rdma-core v27.0 and build it
on-the-fly.

After release of EFA installer 1.9.3, EFA installer will install
rdma-core (>v27), so there is no need to build rdma-core in this
script. This patch remove it.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
