### PR TITLE
Install efa for other providers

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -223,9 +223,7 @@ script_builder()
     type=$1
     set_var
     ${label}_update
-    if [ ${PROVIDER} == "efa" ]; then
-        efa_software_components
-    fi
+    efa_software_components
 
     # The libfabric shm provider use CMA for communication. By default ubuntu
     # disallows non-child process ptrace by, which disable CMA.


### PR DESCRIPTION
Install efa for upd and tcp as well. We no longer build
rdma seperately, instead use rdma packaged with efa
installer. rdma is required for building libfabric
This has been cauing failures
https://libfabric-ci.aws.a2z.com/job/multi-node/PROVIDER=udp,label=alinux/

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
