### PR TITLE
Enable intel MPI test by default

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -12,8 +12,7 @@ if [ ! "$ami_arch" = "x86_64" ] && [ ! "$ami_arch" = "aarch64" ]; then
     echo "Unknown architecture, ami_arch must be x86_64 or aarch64"
     exit 1
 fi
-# Disable IMPI tests for now until apt/yum repo issues are addressed.
-RUN_IMPI_TESTS=${RUN_IMPI_TESTS:-0}
+RUN_IMPI_TESTS=${RUN_IMPI_TESTS:-1}
 ENABLE_PLACEMENT_GROUP=${ENABLE_PLACEMENT_GROUP:-0}
 TEST_SKIP_KMOD=${TEST_SKIP_KMOD:-0}
 get_alinux_ami_id() {


### PR DESCRIPTION
Currently intel MPI test was turned off by default, which is
because of an yum/rpm issue. We are now using the tarball to
install intel MPI, so the issue does not apply any more. This
patch turn on Intel MPI test by default

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
