### PR TITLE
Add Ubuntu 16.04 nccl plugin testcase

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -34,10 +34,10 @@ set_jenkins_variables() {
 find_latest_ami() {
 
     ami=$(aws ec2 describe-images --owners amazon --filters \
-         "Name=name,Values=*$1*" \
-         "Name=state,Values=available" "Name=architecture,Values="x86_64"" \
-         --query 'reverse(sort_by(Images, &CreationDate)[].ImageId)' \
-         --output text | awk '{print $1;}')
+        "Name=name,Values=*$1*" \
+        "Name=state,Values=available" "Name=architecture,Values="x86_64"" \
+        --query 'reverse(sort_by(Images, &CreationDate)[].ImageId)' \
+        --output text | awk '{print $1;}')
     echo ${ami}
 }
 
@@ -498,7 +498,7 @@ EOF
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             --mca btl tcp,self --mca btl_tcp_if_exclude  lo,docker0 \
             --bind-to none ~/aws-ofi-nccl/install/bin/nccl_message_transfer
-        set +xe
+        set +x
         break
     done
 EOF
@@ -534,7 +534,7 @@ EOF
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
             --bind-to none --tag-output --hostfile hosts ~/aws-ofi-nccl/install/bin/nccl_message_transfer
-        set +xe
+        set +x
         break
     done
 EOF
@@ -564,7 +564,7 @@ EOF
         -n $NUM_GPUS -N 8 \
         --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
         --bind-to none $HOME/nccl-tests/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100
-    set +xe
+    set +x
 EOF
 }
 

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -89,9 +89,8 @@ install_libfabric() {
         --enable-efa=${HOME}/rdma-core/build
     make -j 4
     make install
-    echo "export LD_LIBRARY_PATH=${HOME}/libfabric/install/lib/:\$LD_LIBRARY_PATH" >> ~/.bash_profile
-    echo "export LD_LIBRARY_PATH=${HOME}/libfabric/install/lib/:\$LD_LIBRARY_PATH" >> ~/.bashrc
-    source ~/.bash_profile
+    echo "export LD_LIBRARY_PATH=${HOME}/libfabric/install/lib/:\$LD_LIBRARY_PATH" >> ~/.dlamirc
+    source ~/.dlamirc
 }
 
 prepare_libfabric_without_pr() {
@@ -141,6 +140,14 @@ install_nccl_tests() {
 }
 
 install_aws_ofi_nccl_plugin() {
+
+    echo "export LD_LIBRARY_PATH=$HOME/nccl/build/lib:\$LD_LIBRARY_PATH" >> ~/.dlamirc
+    echo "export LD_LIBRARY_PATH=/opt/amazon/openmpi/lib64:\$LD_LIBRARY_PATH" >> ~/.dlamirc
+    echo "export LD_LIBRARY_PATH=/opt/amazon/openmpi/lib:\$LD_LIBRARY_PATH" >> ~/.dlamirc
+    echo "export PATH=/opt/amazon/openmpi/bin:\$PATH" >> ~/.dlamirc
+
+    source ~/.dlamirc
+
     cd $HOME/aws-ofi-nccl
     ./autogen.sh
     ./configure --prefix=$HOME/aws-ofi-nccl/install \
@@ -149,6 +156,7 @@ install_aws_ofi_nccl_plugin() {
                 --with-nccl=$HOME/nccl/build \
                 --with-cuda=${latest_cuda}
     make && make install
+    echo "export LD_LIBRARY_PATH=$HOME/aws-ofi-nccl/install/lib/:\$LD_LIBRARY_PATH" >> ~/.dlamirc
 }
 
 prepare_aws_ofi_nccl_plugin_without_pr() {

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -64,15 +64,15 @@ EOF
 }
 
 install_efa_installer() {
-  curl -o efa_installer.tar.gz ${EFA_INSTALLER_LOCATION}
-  tar -xf efa_installer.tar.gz
-  cd aws-efa-installer
-  # add /opt/amazon/efa and /opt/amazon/openmpi to the PATH
-  . /etc/profile.d/efa.sh
-  sudo ./efa_installer.sh -y
-  # check the version of the installer after installation
-  echo "==> Efa installer version after installation"
-  cat /opt/amazon/efa_installed_packages
+    curl -o efa_installer.tar.gz ${EFA_INSTALLER_LOCATION}
+    tar -xf efa_installer.tar.gz
+    cd aws-efa-installer
+    # add /opt/amazon/efa and /opt/amazon/openmpi to the PATH
+    . /etc/profile.d/efa.sh
+    sudo ./efa_installer.sh -y
+    # check the version of the installer after installation
+    echo "==> Efa installer version after installation"
+    cat /opt/amazon/efa_installed_packages
 }
 
 install_libfabric() {

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -32,9 +32,6 @@ fi
 # Locking NCCL version to 2.5.7-1
 NCCL_2_5_7='3701130b3c1bcdb01c14b3cb70fe52498c1e82b7'
 
-# the last good commit before latest merge which breaks nccl-tests make
-NCCL_TEST_COMMIT='af4fa0f4cf7c2c3db0540da7ac8d6efc1d526635'
-
 # Identify latest CUDA on server
 latest_cuda=$(find /usr/local -maxdepth 1 -type d -iname "cuda*" | sort -V -r | head -1)
 echo "==> Latest CUDA: ${latest_cuda}"
@@ -140,7 +137,6 @@ install_nccl_tests() {
     cd $HOME
     sudo rm -rf nccl-tests
     git clone https://github.com/NVIDIA/nccl-tests.git && cd nccl-tests
-    git checkout ${NCCL_TEST_COMMIT}
     make MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME=$HOME/nccl/build CUDA_HOME=${latest_cuda}
 }
 

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -125,7 +125,8 @@ install_nccl() {
     echo "==> Install NCCL"
     cd $HOME
     sudo rm -rf nccl
-    git clone https://github.com/NVIDIA/nccl.git && cd nccl
+    git clone https://github.com/NVIDIA/nccl.git
+    cd nccl
     git checkout ${NCCL_2_5_7}
     make -j src.build CUDA_HOME=${latest_cuda}
 }
@@ -135,7 +136,8 @@ install_nccl_tests() {
     echo "==> Install NCCL Tests"
     cd $HOME
     sudo rm -rf nccl-tests
-    git clone https://github.com/NVIDIA/nccl-tests.git && cd nccl-tests
+    git clone https://github.com/NVIDIA/nccl-tests.git
+    cd nccl-tests
     make MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME=$HOME/nccl/build CUDA_HOME=${latest_cuda}
 }
 
@@ -155,7 +157,8 @@ install_aws_ofi_nccl_plugin() {
                 --with-libfabric=$HOME/libfabric/install \
                 --with-nccl=$HOME/nccl/build \
                 --with-cuda=${latest_cuda}
-    make && make install
+    make
+    make install
     echo "export LD_LIBRARY_PATH=$HOME/aws-ofi-nccl/install/lib/:\$LD_LIBRARY_PATH" >> ~/.dlamirc
 }
 
@@ -176,12 +179,14 @@ prepare_aws_ofi_nccl_plugin_with_pr() {
     sudo rm -rf aws-ofi-nccl
     if [[ ${TARGET_BRANCH} == 'master' && ${PROVIDER} == 'tcp;ofi_rxm' ]]; then
         echo "==> Configure based on PR, branch: ${TARGET_BRANCH} for provider: ${PROVIDER}"
-        git clone https://github.com/aws/aws-ofi-nccl.git -b 'master' && cd aws-ofi-nccl
+        git clone https://github.com/aws/aws-ofi-nccl.git -b 'master'
+        cd aws-ofi-nccl
         git fetch origin +refs/pull/${PULL_REQUEST_ID}/*:refs/remotes/origin/pr/${PULL_REQUEST_ID}/*
         git checkout ${PULL_REQUEST_REF} -b PRBranch
     elif [[ ${TARGET_BRANCH} == 'aws' && ${PROVIDER} == 'efa' ]]; then
         echo "==> Configure based on PR, branch: ${TARGET_BRANCH} for provider: ${PROVIDER}"
-        git clone https://github.com/aws/aws-ofi-nccl.git -b 'aws' && cd aws-ofi-nccl
+        git clone https://github.com/aws/aws-ofi-nccl.git -b 'aws'
+        cd aws-ofi-nccl
         git fetch origin +refs/pull/${PULL_REQUEST_ID}/*:refs/remotes/origin/pr/${PULL_REQUEST_ID}/*
         git checkout ${PULL_REQUEST_REF} -b PRBranch
     elif [[ ${PROVIDER} == 'efa' ]]; then

--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -220,12 +220,8 @@ case $PLATFORM_ID in
         install_software
         ;;
     ubuntu)
-        # Wait until lock /var/lib/dpkg/lock-frontend released
-        sleep 300
-        # Building aws-ofi-nccl plugin with openmpi throws the following error:
-        # /usr/bin/ld: cannot find -ludev
-        # Installing libudev-dev mitigates the issue
-        sudo apt-get install -y libudev-dev
+        # Wait until lock /var/lib/dpkg/lock-frontend released by unattended security upgrade
+        sleep 400
         install_software
         ;;
     *)


### PR DESCRIPTION
This PR contains the following changes:

Add Ubuntu 16.04 nccl plugin testcase
Use one security group instead of two
Remove custom_ld_library_path
Use latest EFA installer instead fo rdma-core
Add components to initialization scripts
Revert "Use fix commit for nccl-tests to avoid make issue"
Revert "Install missing libudev-dev dependency"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
