### PR TITLE
NCCL tests: Disable OFI MTL for multi-node tests

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -536,21 +536,21 @@ EOF
         set -xe
         timeout 5m /opt/amazon/openmpi/bin/mpirun -n 2 -N 1 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
-            -x RDMAV_FORK_SAFE=1 \
+            -x RDMAV_FORK_SAFE=1 --mca mtl ^ofi \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
             --bind-to none --tag-output --hostfile hosts ~/aws-ofi-nccl/install/bin/nccl_connection
 
         echo "==> Running ring unit test"
         timeout 5m /opt/amazon/openmpi/bin/mpirun -n 3 -N 1 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
-            -x RDMAV_FORK_SAFE=1 \
+            -x RDMAV_FORK_SAFE=1 --mca mtl ^ofi \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
             --bind-to none --tag-output --hostfile hosts ~/aws-ofi-nccl/install/bin/ring
 
         echo "==> Running nccl_message_transfer unit test"
         timeout 5m /opt/amazon/openmpi/bin/mpirun -n 2 -N 1 \
             -x FI_PROVIDER="$PROVIDER" -x FI_EFA_ENABLE_SHM_TRANSFER=0 \
-            -x RDMAV_FORK_SAFE=1 \
+            -x RDMAV_FORK_SAFE=1 --mca mtl ^ofi \
             --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
             --bind-to none --tag-output --hostfile hosts ~/aws-ofi-nccl/install/bin/nccl_message_transfer
         set +x
@@ -581,7 +581,7 @@ EOF
         -x RDMAV_FORK_SAFE=1 \
         -x NCCL_DEBUG=INFO \
         -n $NUM_GPUS -N 8 \
-        --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 \
+        --mca btl tcp,self --mca btl_tcp_if_exclude lo,docker0 --mca mtl ^ofi \
         --bind-to none $HOME/nccl-tests/build/all_reduce_perf -b 8 -e 1G -f 2 -g 1 -c 1 -n 100
     set +x
 EOF


### PR DESCRIPTION
These tests are requesting fork support which the EFA provider cannot
support via the OFI MTL at this time. The tests use MPI for out of band
communication and will fall back on TCP for that here.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
