### PR TITLE
Add support for SLES 15 SP2 and OpenSuse Leap 15.2

### DIFF
--- a/efa-check.sh
+++ b/efa-check.sh
@@ -18,7 +18,7 @@ EOF
 
 libfabric_checks() {
     # Check for libfabric and print the version.
-    libfabric=$(ldconfig -p | tr -d '\t' | grep '^libfabric.so.1')
+    libfabric=$(sudo ldconfig -p | tr -d '\t' | grep '^libfabric.so.1')
     if [ $? -ne 0 ]; then
         cat >&2 << EOF
 Error: libfabric shared library not found.
@@ -150,14 +150,14 @@ EOF
 fi
 
 if grep -q '^nvidia' /proc/modules; then
-    echo "NVIDIA kernel module is loaded, version: $(modinfo -F version nvidia)"
+    echo "NVIDIA kernel module is loaded, version: $(sudo modinfo -F version nvidia)"
 else
     echo "NVIDIA kernel module is not loaded"
 fi
-echo "EFA kernel module is loaded, version: $(modinfo -F version efa)"
+echo "EFA kernel module is loaded, version: $(sudo modinfo -F version efa)"
 
 # Check for rdma-core and print the version.
-libibverbs=$(ldconfig -p | tr -d '\t' | grep '^libibverbs.so.1')
+libibverbs=$(sudo ldconfig -p | tr -d '\t' | grep '^libibverbs.so.1')
 if [ $? -ne 0 ]; then
     cat >&2 << EOF
 Error: libibverbs shared library not found and is required for the EFA
@@ -168,7 +168,7 @@ fi
 
 echo "libibverbs in ldcache: $(readlink -m "$(echo "$libibverbs" | awk '{print $4}')")"
 
-libefa=$(ldconfig -p | tr -d '\t' | grep '^libefa.so.1')
+libefa=$(sudo ldconfig -p | tr -d '\t' | grep '^libefa.so.1')
 if [ $? -ne 0 ]; then
     cat >&2 << EOF
 Error: libefa shared library not found and is required for the EFA

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -34,7 +34,15 @@ efa_software_components_minimal()
     echo "curl ${CURL_OPT} -o efa-installer.tar.gz $EFA_INSTALLER_URL" >> ${tmp_script}
     echo "tar -xf efa-installer.tar.gz" >> ${tmp_script}
     echo "cd \${HOME}/aws-efa-installer" >> ${tmp_script}
-    echo "sudo ./efa_installer.sh -m -y" >> ${tmp_script}
+    # If we are not skipping the kernel module, then add a check for SLES
+    if [ ${TEST_SKIP_KMOD} -eq 0 ]; then
+        sles_allow_module
+    fi
+    if [[ $TEST_SKIP_KMOD -eq 1 ]]; then
+        echo "sudo ./efa_installer.sh -k -m -y" >> ${tmp_script}
+    else
+        echo "sudo ./efa_installer.sh -m -y" >> ${tmp_script}
+    fi
 }
 
 multi_node_efa_minimal_script_builder()


### PR DESCRIPTION
For SLES 15 SP1, install set --allow-unsupported-modules to 1
flag. For Opensuse Leap 15.1 --allow-unsupported-modules is
set to 1 by default, this allows installing latest efa installer

It is required for SUSE to run modinfo and ldconfig as root

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
