### PR TITLE
Convert less than sign to underscore

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -604,10 +604,10 @@ parse_txt_junit_xml()
             # If the line is a command indicated by + sign then assign name tag
             # to it, command is the testname used in the xml
             if [[ ${line} == *${instance_ip_or_id[1]}' +'* ]]; then
-                # Junit deosn't accept quotes or colons in testname in the xml, convert
-                # them to underscores. Parse the command to yaml, by inserting
-                # - name tag before the command
-                echo ${line//[\":]/_} | sed "s/\(${instance_ip_or_id[1]} [+]\+\)\(.*\)/- name: $(printf '%08d\n' $line_no)-\2\n  time: 0\n  result:\n  server_stdout: |/g" \
+                # Junit deosn't accept quotes or colons or less than sign in
+                # testname in the xml, convert them to underscores. Parse the
+                # command to yaml, by inserting - name tag before the command
+                echo ${line//[\"<:]/_} | sed "s/\(${instance_ip_or_id[1]} [+]\+\)\(.*\)/- name: $(printf '%08d\n' $line_no)-\2\n  time: 0\n  result:\n  server_stdout: |/g" \
                 >> ${file_name}
                 line_no=$((${line_no}+1))
             else


### PR DESCRIPTION
Junit does not accept less than sign in the name field of yaml
Replace it with underscore
Failed run:https://libfabric-ci.aws.a2z.com/job/multi-node/PROVIDER=efa,label=alinux/1319/

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
