### PR TITLE
Allow retry on unsupported error

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -252,7 +252,13 @@ create_instance()
     fi
 
     INSTANCE_IDS=''
-    SERVER_ERROR=(InsufficientInstanceCapacity RequestLimitExceeded ServiceUnavailable Unavailable)
+    SERVER_ERROR=(
+    InsufficientInstanceCapacity
+    RequestLimitExceeded
+    ServiceUnavailable
+    Unavailable
+    Unsupported
+    )
     create_instance_count=0
     error=1
     if [ $ami_arch = "x86_64" ] && [ $TEST_GDR -eq 0 ]; then


### PR DESCRIPTION
a1.4xlarge instances are not supported in us-west-2a
region

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
