### PR TITLE
Use product-code to filter opensuse ami.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -20,8 +20,9 @@ TEST_GDR=${TEST_GDR:-0}
 get_opensuse1502_ami_id() {
     region=$1
     # OpenSUSE does not suppport ARM AMI's
+    # openSUSE-Leap-15.2 Build7.1 cabelo@opensuse.org
     aws ec2 describe-images --owners aws-marketplace \
-        --filters 'Name=name,Values=openSUSE-Leap-15.2-?????????-HVM-x86_64*' 'Name=ena-support,Values=true' \
+        --filters 'Name=product-code,Values=5080kaujzrzibjdwrkruspbj7' 'Name=ena-support,Values=true' \
         --output json --region $region | jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'
     return $?
 }


### PR DESCRIPTION
- The current query command for opensuse ami will make it return the latest open suse ami, which includes the micro ami that lacks necessary software stack and should not be used for testing.
- This patch uses product-code to filter open suse ami in market-place. The returned ami will be "aws-marketplace/openSUSE-Leap-15.2-EC2-HVM.x86_64-1.15.2-Build7.1.-548f7b74-f1d6-437e-b650-f6315f6d8aa3-ami-0d27962ec648085f7.4".
- Using a pinned product-code will also prevent user's subscribing newer version of opensuse AMI manually in the future.

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
