### PR TITLE
Revert "Add a fortran ring compile and run test to mpi_ring_c_test.sh"

### DIFF
--- a/mpi_ring_c_test.sh
+++ b/mpi_ring_c_test.sh
@@ -14,7 +14,6 @@ hostfile=$(mktemp)
 out=$(mktemp)
 
 curl ${CURL_OPT} -O https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_c.c
-curl ${CURL_OPT} -O https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_usempi.f90
 
 if [ "${mpi}" == "ompi" ]; then
     ompi_setup
@@ -27,8 +26,6 @@ fi
 
 host_setup ${hostfile} ${hosts}
 mpicc -o /tmp/ring_c ring_c.c
-# Fortran compile test
-mpif90 -o /tmp/ring_usempi ring_usempi.f90
 for host in $hosts; do
     scp /tmp/ring_c $host:/tmp
 done
@@ -37,12 +34,6 @@ $mpirun_cmd --version
 $mpirun_cmd -n $(( $ranks * $# )) -hostfile $hostfile /tmp/ring_c 2>&1 | tee $out
 if [ $? -ne 0 ] || ! grep -q "Process 0 exiting" $out; then
     echo "mpirun ring_c failed"
-    exit 1
-fi
-
-$mpirun_cmd -n $(( $ranks * $# )) -hostfile $hostfile /tmp/ring_usempi 2>&1 | tee $out
-if [ $? -ne 0 ] || ! grep -q "Process 0 exiting" $out; then
-    echo "mpirun ring_usempi (f90) failed"
     exit 1
 fi
 


### PR DESCRIPTION
This reverts commit 9aaef3a903ab9fdc346e7c91ab03eea122f25790.
That commit contains bugs that report false failure.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
