### PR TITLE
Install gfortran dependency for centos/rhel 8.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -450,6 +450,7 @@ EOF
 rhel_install_deps() {
     cat <<-"EOF" >> ${tmp_script}
     sudo yum -y groupinstall 'Development Tools'
+    sudo yum -y install gcc-gfortran
     # python is needed for running fabtests,
     # which is not available on base rhel8 ami.
     if [ ! $(which python) ] && [ ! $(which python2) ] && [ ! $(which python3) ]; then
@@ -467,6 +468,7 @@ centos_update()
 centos_install_deps() {
     cat <<-"EOF" >> ${tmp_script}
     sudo yum -y groupinstall 'Development Tools'
+    sudo yum -y install gcc-gfortran
     # python is needed for running fabtests,
     # which is not available on base centos8 ami.
     if [ ! $(which python) ] && [ ! $(which python2) ] && [ ! $(which python3) ]; then


### PR DESCRIPTION
- gfortran is not included in 'Development Tools` on centos/rhel 8. So we need to install it explicitly.

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
