### PR TITLE
Upgrade lxml after update on SUSE

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -374,7 +374,7 @@ check_provider_os()
     if [ ${label} == "suse" ]; then
         test_ssh $1
         ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@"$1" \
-            "sudo zypper --gpg-auto-import-keys refresh -f && sudo zypper update -y && sudo reboot" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'$1' \1/'
+            "sudo zypper --gpg-auto-import-keys refresh -f && sudo zypper update -y && sudo pip install lxml --upgrade && sudo reboot" 2>&1 | tr \\r \\n | sed 's/\(.*\)/'$1' \1/'
     fi
 }
 #Test SLES15SP2 with allow unsupported modules


### PR DESCRIPTION
Recently, we found on our SUSE's Canary test that
'python3-3.6.12-3.67.2.x86_64' gets installed during
update, and it does not have the symbol `PyFPE_jbuf`.
Accordingly, the package lxml needs to be upgraded.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
