### PR TITLE
Enable using a specific tagged commit when running fabtests

### DIFF
--- a/install-fabtests.sh
+++ b/install-fabtests.sh
@@ -16,6 +16,10 @@ if [ ! -d libfabric ]; then
     git checkout "v${ofi_ver}.x"
     popd
 fi
+if [ ! -z "${target_fabtest_tag}" ]; then
+    cd ${HOME}/libfabric
+    git checkout tags/${target_fabtest_tag}
+fi
 cd ${HOME}/libfabric/fabtests
 ./autogen.sh
 ./configure --with-libfabric=${LIBFABRIC_INSTALL_PATH} \


### PR DESCRIPTION
Currently, when running `install-fabtests.sh`, we cannot use a tagged
commit of libfabric fabtest.

This change introduces an environment variable `target_fabtest_tag`,
by setting it the user can choose which tagged commit to use.

Signed-off-by: Ao Li <aolia@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
