### PR TITLE
Make multinode_runfabtests.sh A Separate File

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -31,37 +31,6 @@ install_libfabric()
     set -x
 }
 
-runfabtests_script_builder()
-{
-    cat <<-"EOF" > multinode_runfabtests.sh
-    . ~/.bash_profile
-    set -xe
-    PROVIDER=$1
-    SERVER_IP=$2
-    CLIENT_IP=$3
-    # Runs all the tests in the fabtests suite while only expanding failed cases
-    EXCLUDE=${HOME}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.exclude
-    if [ -f ${EXCLUDE} ]; then
-        EXCLUDE="-R -f ${EXCLUDE}"
-    else
-        EXCLUDE=""
-    fi
-    runfabtests_script="${HOME}/libfabric/fabtests/install/bin/runfabtests.sh"
-    b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b' || true)"
-    FABTESTS_OPTS="-E LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\" -vvv ${EXCLUDE}"
-    if [ ${PROVIDER} == "efa" ]; then
-        if [ -n "$b_option_available" ]; then
-            FABTESTS_OPTS+=" -b -t all"
-        else
-            gid_c=$4
-            gid_s=$(ibv_devinfo -v | grep GID | awk '{print $3}')
-            FABTESTS_OPTS+=" -C \"-P 0\" -s $gid_s -c $gid_c -t all"
-        fi
-    fi
-    bash -c "$runfabtests_script ${FABTESTS_OPTS} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}"
-EOF
-}
-
 # Runs fabtests on client nodes using INSTANCE_IPS[0] as server
 execute_runfabtests()
 {
@@ -163,8 +132,6 @@ fi
 if [ "$ami_arch" = "aarch64" ]; then
     PROVIDER="tcp"
 fi
-# Prepare runfabtests script to be run on the server (INSTANCE_IPS[0])
-runfabtests_script_builder
 
 execution_seq=$((${execution_seq}+1))
 # SSH into SERVER node and run fabtests

--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -1,0 +1,26 @@
+. ~/.bash_profile
+set -xe
+PROVIDER=$1
+SERVER_IP=$2
+CLIENT_IP=$3
+# Runs all the tests in the fabtests suite while only expanding failed cases
+EXCLUDE=${HOME}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.exclude
+if [ -f ${EXCLUDE} ]; then
+    EXCLUDE="-R -f ${EXCLUDE}"
+else
+    EXCLUDE=""
+fi
+
+runfabtests_script="${HOME}/libfabric/fabtests/install/bin/runfabtests.sh"
+b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b' || true)"
+FABTESTS_OPTS="-E LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\" -vvv ${EXCLUDE}"
+if [ ${PROVIDER} == "efa" ]; then
+    if [ -n "$b_option_available" ]; then
+        FABTESTS_OPTS+=" -b -t all"
+    else
+        gid_c=$4
+        gid_s=$(ibv_devinfo -v | grep GID | awk '{print $3}')
+        FABTESTS_OPTS+=" -C \"-P 0\" -s $gid_s -c $gid_c -t all"
+    fi
+fi
+bash -c "$runfabtests_script ${FABTESTS_OPTS} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}"


### PR DESCRIPTION
Currently, "multinode_runfabtests.sh"
is generated while running "multi-node.sh".

However, sometimes we need to
use "multinode_runfabtests.sh" alone.

So there is a need to make "multinode_runfabtests.sh" as
a separate file.

This commit includes following changes:

1. Adds a new file "multinode_runfabtests.sh". The content of the
file is the same as the "multinode_runfabtests.sh" generated
while running "multi-node.sh"

2. In "multi-node.sh", we do not dynamically build
"multinode_runfabtests.sh". Instead,
we use the "multinode_runfabtests.sh" created by this commit.

Signed-off-by: Ao Li <aolia@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
