### PR TITLE
Use osu micro benchmark artifacts on s3 bucket

### DIFF
--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -13,8 +13,8 @@ hosts=$@
 hostfile=$(mktemp)
 out=$(mktemp)
 
-curl ${CURL_OPT} -O http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz
-osu_dir="osu-micro-benchmarks-5.6.2"
+curl ${CURL_OPT} -O https://subspace-benchmarks-files.s3-us-west-2.amazonaws.com/spack_mirror/osu-micro-benchmarks/osu-micro-benchmarks-5.6.tar.gz
+osu_dir="osu-micro-benchmarks-5.6"
 one_rank_per_node=""
 if [ "${mpi}" == "ompi" ]; then
     ompi_setup


### PR DESCRIPTION
This patch use the osu micro benchmark artifacts we mirrored
on s3 bucket because it is more stable.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
