### PR TITLE
Fix exit code for background process

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -55,11 +55,15 @@ set -x
 INSTANCE_IDS=($INSTANCE_IDS)
 
 execution_seq=$((${execution_seq}+1))
+pids=""
 # Wait until all instances have passed status check
 for ID in ${INSTANCE_IDS[@]}; do
     test_instance_status "$ID" &
+    pids="$pids $!"
 done
-wait
+for pid in $pids; do
+    wait $pid || { echo "==>Instance status check failed"; exit 65; }
+done
 
 get_instance_ip
 INSTANCE_IPS=($INSTANCE_IPS)


### PR DESCRIPTION
Use pid to get the exit code for background
processes. If an error occurs during instance
status check, mark the buil unstable by passing
error code 65

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
