### PR TITLE
Run fi_dgram_pingpong seperately with out of band synchronization.

### DIFF
--- a/install-fabtests.sh
+++ b/install-fabtests.sh
@@ -30,10 +30,21 @@ make install
 
 # Runs all the tests in the fabtests suite between two nodes while only expanding failed cases
 EXCLUDE=${HOME}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.exclude
-if [ -f ${EXCLUDE} ]; then
-    EXCLUDE="-R -f ${EXCLUDE}"
-else
-    EXCLUDE=""
+if [ "${PROVIDER}" == "efa" ]; then
+    if [ ! -f ${EXCLUDE} ]; then
+        echo "exclude file for efa does not exist! Exiting ..."
+        exit 1
+    fi
+
+    # fi_dgram_pingpong test assums packet delivery, which dgram end point
+    # does not guarantee. As a result, this test only works with out of
+    # band synchronization (-b option). However, runfabtests.sh run all
+    # the tests with in band synchronization (-E option).
+    # Therefore we exclude it from runfabtests.sh and run this test
+    # separately with -b option in multinode_runfabtests.sh
+    echo "# skip dgram_pingpong test" >> ${EXCLUDE}
+    echo "dgram_pingpong" >> ${EXCLUDE}
+    echo "" >> ${EXCLUDE}
 fi
 # .bashrc and .bash_profile are loaded differently depending on distro and
 # whether the shell is interactive or not, just do both to be safe.

--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -1,4 +1,42 @@
 . ~/.bash_profile
+
+run_dgram_pingpong_with_b()
+{
+    SERVER_IP=$1
+    CLIENT_IP=$2
+    dgram_pingpong="${HOME}/libfabric/fabtests/install/bin/fi_dgram_pingpong"
+    ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${SERVER_IP} ${dgram_pingpong} -k -p efa -b >& server.out &
+    server_pid=$!
+    sleep 1
+
+    ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${CLIENT_IP} ${dgram_pingpong} -k -p efa -b ${SERVER_IP} >& client.out &
+    client_pid=$!
+
+    wait $client_pid
+    client_ret=$?
+    if [ $client_ret -ne 0 ]; then
+        kill -9 $server_pid
+    fi
+
+    wait $server_pid
+    server_ret=$?
+    if [ $server_ret -eq 0 ] && [ $client_ret -eq 0 ]; then
+        echo "fi_dgram_pingpong test passed!"
+        ret=0
+    else
+        echo "fi_dgram_pingpong test failed!"
+        ret=1
+    fi
+
+    echo "server output:"
+    cat server.out
+
+    echo "client output:"
+    cat client.out
+
+    return $ret
+}
+
 set -xe
 PROVIDER=$1
 SERVER_IP=$2
@@ -11,6 +49,14 @@ else
     EXCLUDE=""
 fi
 
+# Each individual test has a "-b" option and "-E" option. Both will
+# use out-of-band address exchange.
+# The difference is "-b" will use out-of-band synchronization, -E
+# does not.
+#
+# runfabtests.sh's "-b" option actually uses the -E option of each indivdual
+# test (for historical reasons).
+#
 runfabtests_script="${HOME}/libfabric/fabtests/install/bin/runfabtests.sh"
 b_option_available="$($runfabtests_script -h 2>&1 | grep '\-b' || true)"
 FABTESTS_OPTS="-E LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\" -vvv ${EXCLUDE}"
@@ -24,3 +70,11 @@ if [ ${PROVIDER} == "efa" ]; then
     fi
 fi
 bash -c "$runfabtests_script ${FABTESTS_OPTS} ${PROVIDER} ${SERVER_IP} ${CLIENT_IP}"
+
+if [ ${PROVIDER} == "efa" ]; then
+    # dgram_pingpong test has been excluded during installation
+    # (in install-fabtests.sh), because it does not work with "-E" option.
+    # So here we run it separately using "-b" option
+    echo "Run fi_dgram_pingpong with out-of-band synchronization"
+    run_dgram_pingpong_with_b ${SERVER_IP} ${CLIENT_IP}
+fi


### PR DESCRIPTION
fi_dgram_pingpong assume packet delivery, which dgram
does not guarantee. As a result, fi_dgram_pingpong test randomly
fails. This patch addresses the issue by running fi_dgram_pingpong
test seperately using the out of band synchronization.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
