### PR TITLE
single-node.sh set EXCLUDE by itself

### DIFF
--- a/single-node.sh
+++ b/single-node.sh
@@ -35,6 +35,13 @@ cat ${HOME}/.ssh/id_rsa.pub >> ${HOME}/.ssh/authorized_keys
 
 runfabtests_script="${HOME}/libfabric/fabtests/install/bin/runfabtests.sh"
 
+EXCLUDE=${HOME}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.exclude
+if [ -f ${EXCLUDE} ]; then
+    EXCLUDE="-R -f ${EXCLUDE}"
+else
+    EXCLUDE=""
+fi
+
 # Provider-specific handling of the options passed to runfabtests.sh
 FABTESTS_OPTS="-E LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH\" -vvv ${EXCLUDE}"
 case "${PROVIDER}" in


### PR DESCRIPTION
single-node.sh uses the envrionment variable EXCLUDE. However it
does not set EXCLUDE itself, but rely on install-libfabric.sh to
set EXCLUDE

install-libfabric.sh itself does not use EXCLUDE, and was changed
to not set EXCLUDE by a recent change 449b1780ca33, which broke
the single node test.

This patch address the issue by letting single-node.sh set
EXCLUDE for itself.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
