### PR TITLE
Switch from CURL to WGET

### DIFF
--- a/efa-check.sh
+++ b/efa-check.sh
@@ -3,9 +3,9 @@
 
 # Script to verify EFA configuration and assist with debugging.
 
+source ~/wget_check.sh
 VENDOR_ID="0x1d0f"
 DEV_ID="0xefa0"
-CURL_OPT="--retry 5"
 usage() {
 cat << EOF
 usage: $(basename "$0") [options]
@@ -85,7 +85,9 @@ echo "======== Instance / Device check ========"
 # Get instance type
 if command -v curl >/dev/null 2>&1; then
     metadata_url="http://169.254.169.254/latest/meta-data/instance-type"
-    echo "Instance type: $(curl -m 1 ${CURL_OPT} $metadata_url 2>/dev/null)"
+    wget_check "$metadata_url" "instance-type"
+    instance=$(cat instance-type)
+    echo "Instance type: ${instance}"
 fi
 
 # Determine if an EFA device is present and print device list.

--- a/install-impi.sh
+++ b/install-impi.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-curl ${CURL_OPT} -O https://s3.us-west-2.amazonaws.com/subspace-intelmpi/l_mpi_2019.10.317.tgz
+source ~/wget_check.sh
+wget_check "https://s3.us-west-2.amazonaws.com/subspace-intelmpi/l_mpi_2019.10.317.tgz" "l_mpi_2019.10.317.tgz"
 tar -zxf l_mpi_2019.10.317.tgz
 cd l_mpi_2019.10.317
 sed -e "s/decline/accept/" silent.cfg > accept.cfg

--- a/install-nvidia-driver.sh
+++ b/install-nvidia-driver.sh
@@ -5,6 +5,7 @@
 # to keep whatever we install before the EFA installer to a minimum to
 # try to match what a customer will do.
 
+source ~/wget_check.sh
 os_name="$(. /etc/os-release; echo $NAME)"
 os_version_id="$(. /etc/os-release; echo $VERSION_ID)"
 if [  "$os_name" == "Ubuntu" ]; then
@@ -28,7 +29,7 @@ if [ "$os_name" = "CentOS Linux" ] || [ "$os_name" = "Red Hat Enterprise Linux" 
         sudo yum install -y dkms
     fi
 fi
-curl --retry 5 -O https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run
+wget_check "https://developer.download.nvidia.com/compute/cuda/11.0.3/local_installers/cuda_11.0.3_450.51.06_linux.run" "cuda_11.0.3_450.51.06_linux.run"
 chmod +x cuda_11.0.3_450.51.06_linux.run
 sudo sh cuda_11.0.3_450.51.06_linux.run --override --silent
 echo "export PATH=/usr/local/cuda/bin:/usr/local/cuda/NsightCompute-2019.1:\$PATH" >> ~/.bash_profile

--- a/install-nvidia-fabric-manager.sh
+++ b/install-nvidia-fabric-manager.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+source ~/wget_check.sh
 os_name="$(. /etc/os-release; echo $NAME)"
 os_version_id="$(. /etc/os-release; echo $VERSION_ID)"
 # Make the version the same with nvidia driver
@@ -25,7 +26,7 @@ else
     pkg_name="nvidia-fabricmanager-450-${pkg_version}-1.${pkg_arch_label}.rpm"
 fi
 pkg_repo="https://developer.download.nvidia.com/compute/cuda/repos/${pkg_distribution}/x86_64"
-curl --retry 5 -O ${pkg_repo}/${pkg_name}
+wget_check "${pkg_repo}/${pkg_name}" "${pkg_name}"
 if [ "$os_name" == "Ubuntu" ]; then
     sudo apt install -y ./${pkg_name}
 elif [ "$os_name" == "OpenSUSE Leap" ] || [ "$os_name" == "SLES" ]; then

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # MPI helper shell functions
-CURL_OPT="--retry 5"
 # Detect architecture
 ARCH=$(uname -m)
 if [ ! "$ARCH" = "x86_64" ] && [ ! "$ARCH" = "aarch64" ]; then

--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -2,7 +2,7 @@
 
 source ~/.bash_profile
 source ~/mpi_common.sh
-
+source ~/wget_check.sh
 set -x
 set -o pipefail
 mpi=$1
@@ -13,7 +13,7 @@ hosts=$@
 hostfile=$(mktemp)
 out=$(mktemp)
 
-curl ${CURL_OPT} -O http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz
+wget_check "http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz" "osu-micro-benchmarks-5.6.2.tar.gz"
 osu_dir="osu-micro-benchmarks-5.6.2"
 one_rank_per_node=""
 if [ "${mpi}" == "ompi" ]; then

--- a/mpi_ring_c_test.sh
+++ b/mpi_ring_c_test.sh
@@ -2,6 +2,7 @@
 
 source ~/.bash_profile
 source ~/mpi_common.sh
+source ~/wget_check.sh
 
 set -x
 set -o pipefail
@@ -14,8 +15,8 @@ hostfile=$(mktemp)
 out1=$(mktemp)
 out2=$(mktemp)
 
-curl ${CURL_OPT} -O https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_c.c
-curl ${CURL_OPT} -O https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_usempi.f90
+wget_check "https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_c.c" "ring_c.c"
+wget_check "https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_usempi.f90" "ring_usempi.f90"
 
 if [ "${mpi}" == "ompi" ]; then
     ompi_setup

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -75,6 +75,11 @@ INSTANCE_IPS=($INSTANCE_IPS)
 # Prepare AMI specific libfabric installation script
 script_builder multi-node
 
+for IP in ${INSTANCE_IPS[@]}; do
+    scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} \
+        $WORKSPACE/libfabric-ci-scripts/wget_check.sh \
+        ${ami[1]}@${IP}:~/
+done
 # Generate ssh key for fabtests
 set +x
 if [ ! -f $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair} ]; then

--- a/single-node.sh
+++ b/single-node.sh
@@ -20,6 +20,10 @@ test_instance_status ${INSTANCE_IDS}
 
 get_instance_ip
 
+scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} \
+            $WORKSPACE/libfabric-ci-scripts/wget_check.sh \
+            ${ami[1]}@${INSTANCE_IPS}:~/
+
 execution_seq=$((${execution_seq}+1))
 # Kernel upgrade only for Ubuntu and provider EFA
 check_provider_os ${INSTANCE_IPS}

--- a/wget_check.sh
+++ b/wget_check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Loads wget_check function which downloads files using wget.
+# The following two flags are used with wget
+# 1) tries: set to 5, retry 5 times in case of a failure
+# 2) content-on-error: If an error occurs download the error webpage
+# If an error occurs wget saves the error webpage in the filename
+# provided during download (generally .tar format). We need to rename
+# it to .html format, to cat it to stdout
+
+WGET_OPT="--tries=5 --content-on-error"
+
+function wget_check {
+    url=$1
+    file_name=$2
+    bash_option=$-
+    restore_e=0
+    if [[ $bash_option =~ e ]]; then
+        restore_e=1
+        set +e
+    fi
+    # bash -c is used to avoid issues due to quotation within quotation
+    bash -c "wget ${WGET_OPT} -O $file_name $url"
+    if [ $? -ne 0 ]; then
+        if [ -f "$file_name" ]; then
+            # Only if the file type has ASCII text output the file
+            if [[ $(file $file_name | grep "ASCII") =~ "ASCII" ]]; then
+                cat $file_name
+            fi
+        fi
+        exit 1
+    fi
+    if [ $restore_e -eq 1 ]; then
+        set -e
+    fi
+}


### PR DESCRIPTION
Curl will always return a response code of 0
indicating success for failed commands. I tried
different curl flags -w "Code: %{response_code}\n"
returns success(code 200) for SSL errors, -f
suppresses the error webpage.
Switched command from curl to wget, as wget
will fail if an error occurs(returns a non zero
exit code). For wget the error page is not outputted
by default to do this --content-on-error flag is added

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
