### PR TITLE
Install wget in nvidia-driver script

### DIFF
--- a/install-nvidia-driver.sh
+++ b/install-nvidia-driver.sh
@@ -23,6 +23,7 @@ else
 fi
 
 if [ "$os_name" = "CentOS Linux" ] || [ "$os_name" = "Red Hat Enterprise Linux" ]; then
+    sudo yum -y install wget
     if [ "$os_version_id" = "8" ] || echo "${os_version_id}" | grep -q '8\.[0-9]' ; then
         sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         sudo yum config-manager --enable epel


### PR DESCRIPTION
nvidia-driver is a standalone script and can be run
as soon as the instance is launched. Install
wget in here

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
