### PR TITLE
Fix a bug in nvidia driver installation

### DIFF
--- a/install-nvidia-driver.sh
+++ b/install-nvidia-driver.sh
@@ -22,7 +22,7 @@ else
     sudo yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
 fi
 
-if [ "$os_name" = "CentOS Linux" ] || [ "$os_name" = "Red Hat Enterprise Linux" ]; then
+if [ "$os_name" = "CentOS Linux" ] || [[ "$os_name" =~ "Red Hat Enterprise Linux" ]]; then
     sudo yum -y install wget
     if [ "$os_version_id" = "8" ] || echo "${os_version_id}" | grep -q '8\.[0-9]' ; then
         sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm


### PR DESCRIPTION
Wget will be installed only on rhel8 and not rhel7
due to different os_name. This PR fixes that issue

rhle7* os name: Red Hat Enterprise Linux Server
rhel8* os name: Red Hat Enterprise Linux

Signed-off-by: Dipti Kothari <dkothar@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
