### PR TITLE
Add --no-verbose option for wget.

### DIFF
--- a/wget_check.sh
+++ b/wget_check.sh
@@ -8,7 +8,7 @@
 # provided during download (generally .tar format). We need to rename
 # it to .html format, to cat it to stdout
 
-WGET_OPT="--tries=5 --content-on-error"
+WGET_OPT="--tries=5 --content-on-error --no-verbose"
 
 function wget_check {
     url=$1


### PR DESCRIPTION
wget outputs a large number of lines as the percentage of downloading,
which introduces useless lines in the log and makes the log reading
more difficult. Add a --no-verbose (-nv) option to turn off its verbose
printing without being quiet.

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
