### PR TITLE
Use c5.18xlarge instance for tcp/udp/shm test

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -272,6 +272,7 @@ create_instance()
                 fi
                 ;;
             tcp|udp|shm)
+                instance_type=c5.18xlarge
                 network_interface="[{\"DeviceIndex\":0,\"DeleteOnTermination\":true,\"Groups\":[\"${slave_security_group}\"]"
                 ;;
             *)


### PR DESCRIPTION
Currently tcp/udp/shm test are running on c5.large
instances, which does not enough memory to run EFA
installer. This commit switch to use larger instance
for these test.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
