### PR TITLE
Change placement group to use date-time for unique identifier

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -199,7 +199,9 @@ create_pg()
     if [ ${ENABLE_PLACEMENT_GROUP} -eq 0 ]; then
         return 0
     fi
-    PLACEMENT_GROUP="slave-pg-$RANDOM"
+    #Month - Day - Year - Hour - Minute - Second
+    date_time=$(date +'%m-%d-%Y-%H-%M-%S')
+    PLACEMENT_GROUP="slave-pg-${date_time}-${BUILD_NUMBER}-${RANDOM}"
     AWS_DEFAULT_REGION=us-west-2 aws ec2 create-placement-group \
         --group-name ${PLACEMENT_GROUP} \
         --strategy cluster


### PR DESCRIPTION
The $RANDOM var was insufficient for selecting unique ID's. Occasionally
we would hit duplicate placement group ID's due to selecting a number
that already existed. Using date time will avoid this issue.

Signed-off-by: William Zhang <wilzhang@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
