### PR TITLE
Use SSH connection test to check if the instance is ready

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -58,19 +58,20 @@ create_instance || { echo "==>Unable to create instance"; exit 65; }
 set -x
 INSTANCE_IDS=($INSTANCE_IDS)
 
+get_instance_ip
+INSTANCE_IPS=($INSTANCE_IPS)
+
 execution_seq=$((${execution_seq}+1))
 pids=""
-# Wait until all instances have passed status check
-for ID in ${INSTANCE_IDS[@]}; do
-    test_instance_status "$ID" &
+# Wait until all instances have passed SSH connection check
+for IP in ${INSTANCE_IPS[@]}; do
+    test_ssh "$IP" &
     pids="$pids $!"
 done
 for pid in $pids; do
-    wait $pid || { echo "==>Instance status check failed"; exit 65; }
+    wait $pid || { echo "==>Instance ssh check failed"; exit 65; }
 done
 
-get_instance_ip
-INSTANCE_IPS=($INSTANCE_IPS)
 
 # Prepare AMI specific libfabric installation script
 script_builder multi-node

--- a/single-node.sh
+++ b/single-node.sh
@@ -15,10 +15,11 @@ set +x
 create_instance || { echo "==>Unable to create instance"; exit 65; }
 set -x
 
-execution_seq=$((${execution_seq}+1))
-test_instance_status ${INSTANCE_IDS}
-
 get_instance_ip
+
+execution_seq=$((${execution_seq}+1))
+test_ssh ${INSTANCE_IPS}
+
 
 scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} \
             $WORKSPACE/libfabric-ci-scripts/wget_check.sh \


### PR DESCRIPTION
We used to check the instance status by calling
"aws ec2 describe-instance-status" in a loop, and set the
loop count to 100. But the check sometime still fails with
"insufficient data".

Use SSH connection test to check if the instance is ready,
instead. It retries with exponential backoff.
The initial backoff is 30s, and doubles for each retry,
until the maximum backoff (16 minutes).

Signed-off-by: Jie Zhang <zhngaj@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
