### PR TITLE
NCCL OFI Scripts [Bug Fix]: Rename libfabric repo branch

### DIFF
--- a/nccl/common/prep_ami.sh
+++ b/nccl/common/prep_ami.sh
@@ -126,7 +126,7 @@ prepare_libfabric_without_pr() {
     echo "==> Building libfabric"
     cd ${HOME}
     sudo rm -rf libfabric
-    git clone https://github.com/ofiwg/libfabric -b 'master'
+    git clone https://github.com/ofiwg/libfabric -b 'main'
 }
 
 prepare_libfabric_with_pr() {


### PR DESCRIPTION
ofiwg/libfabric git repo master branch has been renamed to main

Signed-off-by: Oleksandr Zubenko <zubeno@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
