### PR TITLE
Enable ARM testing with tcp and efa providers.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -107,9 +107,19 @@ create_instance()
     elif [ $BUILD_GDR -eq 1 ]; then
         instance_type=p4d.24xlarge
         network_interface="[{\"DeviceIndex\":0,\"DeleteOnTermination\":true,\"InterfaceType\":\"efa\",\"Groups\":[\"${slave_security_group}\"]"
-    else
-        instance_type=a1.4xlarge
-        network_interface="[{\"DeviceIndex\":0,\"DeleteOnTermination\":true,\"Groups\":[\"${slave_security_group}\"]"
+    elif [ $ami_arch = "aarch64" ]; then
+        case "${PROVIDER}" in
+            efa)
+                instance_type=c6gn.16xlarge
+                network_interface="[{\"DeviceIndex\":0,\"DeleteOnTermination\":true,\"InterfaceType\":\"efa\",\"Groups\":[\"${slave_security_group}\"]"
+                ;;
+            tcp)
+                instance_type=a1.4xlarge
+                network_interface="[{\"DeviceIndex\":0,\"DeleteOnTermination\":true,\"Groups\":[\"${slave_security_group}\"]"
+                ;;
+            *)
+                exit 1
+        esac
     fi
     addl_args=""
     if [ ${ENABLE_PLACEMENT_GROUP} -eq 1 ]; then

--- a/efa-check.sh
+++ b/efa-check.sh
@@ -5,7 +5,14 @@
 
 source ~/wget_check.sh
 VENDOR_ID="0x1d0f"
-DEV_ID="0xefa0"
+ami_arch="$(uname -m)"
+if [ "${ami_arch}" == "x86_64" ]; then
+    DEV_ID="0xefa0"
+elif [ "${ami_arch}" == "aarch64" ]; then
+    DEV_ID="0xefa1"
+else
+    echo "Unknown architecture, exiting."
+fi
 usage() {
 cat << EOF
 usage: $(basename "$0") [options]

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -9,9 +9,8 @@ if [ ! "$ARCH" = "x86_64" ] && [ ! "$ARCH" = "aarch64" ]; then
 fi
 function check_efa_ompi {
     out=$1
-    grep -q "mtl:ofi:prov: efa" $out
     # TODO: Remove the conditional of [ "$ARCH" = "x86_64" ] when we start testing openmpi with EFA on ARM instances.
-    if [ "$ARCH" = "x86_64" ] && [ $? -ne 0 ]; then
+    if [ "$ARCH" = "x86_64" ] && ! grep -q "mtl:ofi:prov: efa" $out; then
         echo "efa provider not used with Open MPI"
         exit 1
     fi
@@ -19,9 +18,8 @@ function check_efa_ompi {
 
 function check_efa_impi {
     out=$1
-    grep -q "libfabric provider: efa" $out
     # TODO: Remove the conditional of [ "$ARCH" = "x86_64" ] when we start testing openmpi with EFA on ARM instances.
-    if [ "$ARCH" = "x86_64" ] && [ $? -ne 0 ]; then
+    if [ "$ARCH" = "x86_64" ] && ! grep -q "libfabric provider: efa" $out; then
         echo "efa provider not used with Intel MPI"
         exit 1
     fi

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -31,7 +31,8 @@ function ompi_setup {
     # There is no EFA enabled ARM instance right now.
     # Open MPI will pick btl/tcp itself.
     if [ $ARCH = "x86_64" ]; then
-        export OMPI_MCA_mtl_base_verbose=100
+        # Get the mtl:ofi:prov information in verbose output
+        export OMPI_MCA_opal_common_ofi_verbose=1
     else
         export OMPI_MCA_btl_base_verbose=100
     fi

--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -69,11 +69,18 @@ elif [ "${mpi}" == "impi" ] && [ "$provider" == "efa" ]; then
     check_efa_impi $out
 fi
 
+# osu_mbw_mr test takes more than 30 min when running with tcp provider.
+# Increase its timeout limit to 3600 secs.
+MPIEXEC_TIMEOUT_ORIG=${MPIEXEC_TIMEOUT}
+if [ "$provider" = "tcp" ]; then
+    MPIEXEC_TIMEOUT=3600
+fi
 $mpirun_cmd -n $(( $ranks * $# )) -hostfile $hostfile /tmp/${osu_dir}/mpi/pt2pt/osu_mbw_mr 2>&1 | tee $out
 if [ $? -ne 0 ]; then
     echo "osu_mbw_mr failed"
     exit 1
 fi
+MPIEXEC_TIMEOUT=${MPIEXEC_TIMEOUT_ORIG}
 
 if [ "${mpi}" == "ompi" ] && [ "$provider" == "efa" ]; then
     check_efa_ompi $out

--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -9,6 +9,8 @@ mpi=$1
 shift
 libfabric_job_type=$1
 shift
+provider=$1
+shift
 hosts=$@
 hostfile=$(mktemp)
 out=$(mktemp)
@@ -17,7 +19,7 @@ wget_check "http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchma
 osu_dir="osu-micro-benchmarks-5.6.2"
 one_rank_per_node=""
 if [ "${mpi}" == "ompi" ]; then
-    ompi_setup
+    ompi_setup "${provider}"
     one_rank_per_node="-N 1"
 elif [ "${mpi}" == "impi" ]; then
     impi_setup "${libfabric_job_type}"
@@ -49,9 +51,9 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ "${mpi}" == "ompi" ]; then
+if [ "${mpi}" == "ompi" ] && [ "$provider" == "efa" ]; then
     check_efa_ompi $out
-elif [ "${mpi}" == "impi" ]; then
+elif [ "${mpi}" == "impi" ] && [ "$provider" == "efa" ]; then
     check_efa_impi $out
 fi
 
@@ -61,9 +63,9 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ "${mpi}" == "ompi" ]; then
+if [ "${mpi}" == "ompi" ] && [ "$provider" == "efa" ]; then
     check_efa_ompi $out
-elif [ "${mpi}" == "impi" ]; then
+elif [ "${mpi}" == "impi" ] && [ "$provider" == "efa" ]; then
     check_efa_impi $out
 fi
 
@@ -73,9 +75,9 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-if [ "${mpi}" == "ompi" ]; then
+if [ "${mpi}" == "ompi" ] && [ "$provider" == "efa" ]; then
     check_efa_ompi $out
-elif [ "${mpi}" == "impi" ]; then
+elif [ "${mpi}" == "impi" ] && [ "$provider" == "efa" ]; then
     check_efa_impi $out
 fi
 

--- a/mpi_ring_c_test.sh
+++ b/mpi_ring_c_test.sh
@@ -10,6 +10,8 @@ mpi=$1
 shift
 libfabric_job_type=$1
 shift
+provider=$1
+shift
 hosts=$@
 hostfile=$(mktemp)
 out1=$(mktemp)
@@ -19,7 +21,7 @@ wget_check "https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring
 wget_check "https://raw.githubusercontent.com/open-mpi/ompi/master/examples/ring_usempi.f90" "ring_usempi.f90"
 
 if [ "${mpi}" == "ompi" ]; then
-    ompi_setup
+    ompi_setup "${provider}"
 elif [ "${mpi}" == "impi" ]; then
     impi_setup "${libfabric_job_type}"
 else
@@ -49,10 +51,10 @@ if [ $? -ne 0 ] || ! grep -q "Process  0 exiting" $out2; then
     exit 1
 fi
 
-if [ "${mpi}" == "ompi" ]; then
+if [ "${mpi}" == "ompi" ] && [ "$provider" == "efa" ]; then
     check_efa_ompi $out1
     check_efa_ompi $out2
-elif [ "${mpi}" == "impi" ]; then
+elif [ "${mpi}" == "impi" ] && [ "$provider" == "efa" ]; then
     check_efa_impi $out1
     check_efa_impi $out2
 fi


### PR DESCRIPTION
The current script only supports running arm archi AMI tests on a1.4xlarge
instances with tcp provider. This patch enables the arm testing with both
tcp and efa provider.
$PROVIDER is an environment variable preset before running the scripts.
When PROVIDER=efa, run arm test on c6gn.16xlarge instances.
When PROVIDER=tcp, run arm test on a1.4xlarge instances.
Also fix a bug in check_efa_ompi and check_efa_impi in mpi_common.sh