### PR TITLE
Modify the placement group name to be inclusive.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -23,7 +23,7 @@ create_pg()
     fi
     #Month - Day - Year - Hour - Minute - Second
     date_time=$(date +'%m-%d-%Y-%H-%M-%S')
-    PLACEMENT_GROUP="slave-pg-${date_time}-${BUILD_NUMBER}-${RANDOM}"
+    PLACEMENT_GROUP="compute-pg-${date_time}-${BUILD_NUMBER}-${RANDOM}"
     AWS_DEFAULT_REGION=us-west-2 aws ec2 create-placement-group \
         --group-name ${PLACEMENT_GROUP} \
         --strategy cluster


### PR DESCRIPTION
Currently, the placement group created by libfabric-ci-scripts
is named slave-pg*, which contains non-inclusive word.
Change it to "compute-pg*" to be inclusive.

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
