### PR TITLE
NCCL OFI Scripts [Bug Fix]: Use Deep Learning Base AMI (Ubuntu 18.04)

### DIFF
--- a/nccl/common/nccl-common.sh
+++ b/nccl/common/nccl-common.sh
@@ -73,8 +73,8 @@ set_aws_defaults() {
     echo "==> Latest Deep Learning AMI (Ubuntu 16.04): ${ami_ubuntu_16_04}"
 
     # The latest Deep Learning AMI Ubuntu 18.04 Image
-    ami_ubuntu_18_04=$(find_latest_ami "Deep Learning AMI (Ubuntu 18.04)")
-    echo "==> Latest Deep Learning AMI (Ubuntu 18.04): ${ami_ubuntu_18_04}"
+    ami_ubuntu_18_04=$(find_latest_ami "Deep Learning Base AMI (Ubuntu 18.04)")
+    echo "==> Latest Deep Learning Base AMI (Ubuntu 18.04): ${ami_ubuntu_18_04}"
 }
 
 define_parameters() {


### PR DESCRIPTION
Use Deep Learning Base AMI to mitigate
NVIDIA Fabric Manager and Driver versions mismatch

Signed-off-by: Oleksandr Zubenko <zubeno@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
