### PR TITLE
Fix a bug and refactor the boot_finished_check function.

### DIFF
--- a/boot-finished-check.sh
+++ b/boot-finished-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This script waits up to 10 minutes for cloud-init to finish
+# Usage: /bin/bash boot_finished_check.sh
+
+retry=20
+while [[ $retry -ge 0 ]]; do
+    if [ -f /var/lib/cloud/instance/boot-finished ]; then
+        break
+    else
+        retry=$((retry - 1))
+        sleep 30
+    fi
+done
+if [ -f /var/lib/cloud/instance/boot-finished ]; then
+    echo "Cloud-init completed successfully."
+else
+    echo "Cloud-init failed to finish."
+    exit 1
+fi

--- a/common.sh
+++ b/common.sh
@@ -313,26 +313,6 @@ set_var()
 EOF
 }
 
-# Wait up to 10 minutes for cloud-init to finish
-boot_finished_check()
-{
-    retry=20
-    while [[ $retry -ge 0 ]]; do
-        if [ -f /var/lib/cloud/instance/boot-finished ]; then
-            break
-        else
-            retry=$((retry - 1))
-            sleep 30
-        fi
-    done
-    if [ -f /var/lib/cloud/instance/boot-finished ]; then
-        echo "Cloud-init completed successfully."
-    else
-        echo "Cloud-init failed to finish."
-        exit 1
-    fi
-}
-
 # Poll for the SSH daemon to come up before proceeding.
 # The SSH poll retries with exponential backoff.
 # The initial backoff is 30s, and doubles for each retry, until 16 minutes.
@@ -351,7 +331,7 @@ test_ssh()
             slave_ready=0
             set -xe
             # Checks to see if cloud-init has finished
-            ssh -T -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o BatchMode=yes -i ~/${slave_keypair} ${ami[1]}@$1 "$(typeset -f); boot_finished_check"
+            ssh -T -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o BatchMode=yes -i ~/${slave_keypair} ${ami[1]}@$1 "bash -s" -- < $WORKSPACE/libfabric-ci-scripts/boot-finished-check.sh
             echo "SSH connection of instance $1 is ready"
             return 0
         fi

--- a/common.sh
+++ b/common.sh
@@ -317,10 +317,13 @@ EOF
 boot_finished_check()
 {
     retry=20
-    until [ -f /var/lib/cloud/instance/boot-finished ]; do
-        echo "Cloud-init ongoing. Waiting..."
-        retry=$((retry - 1))
-        sleep 30
+    while [[ $retry -ge 0 ]]; do
+        if [ -f /var/lib/cloud/instance/boot-finished ]; then
+            break
+        else
+            retry=$((retry - 1))
+            sleep 30
+        fi
     done
     if [ -f /var/lib/cloud/instance/boot-finished ]; then
         echo "Cloud-init completed successfully."


### PR DESCRIPTION
This PR contains two commits

commit 13d5608cea8ad91249a9287cf146e7abcf43bad7 (HEAD -> cloud-init, origin/cloud-init)
Author: Shi Jin <sjina@amazon.com>
Date:   Mon Jul 26 18:03:46 2021 -0700

    Run boot_finished_check as a bash script over ssh.

    Currently, "type -f" is set before running the boot_finished_check function
    in local script over ssh. This displays the whole common.sh script and introduces
    irrelavant printings in the log. This patch rewrites this function as a bash
    script that can be executed over ssh.

    Signed-off-by: Shi Jin <sjina@amazon.com>

commit b6e56ee72d709c7d6ee6468e955fb14a41790572
Author: Shi Jin <sjina@amazon.com>
Date:   Wed Jul 21 15:01:56 2021 -0700

    Fix a bug in boot_finished_check.

    Currently there is no break condition on retry number
    within the "until" loop in this function, which makes
    the until loop has infinite retry if the
    "/var/lib/cloud/instance/boot-finished" does not exist.
    This patch fixes this issue.

    Signed-off-by: Shi Jin <sjina@amazon.com>
