### PR TITLE
Set btl base verbose output for component

### DIFF
--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -24,7 +24,8 @@ function ompi_setup {
         # Get the mtl:ofi:prov information in verbose output
         export OMPI_MCA_opal_common_ofi_verbose=1
     else
-        export OMPI_MCA_btl_base_verbose=100
+        # Get btl base verbose output for component
+        export OMPI_MCA_btl_base_verbose=10
     fi
     # Pass LD_LIBRARY_PATH arg so that we use the right libfabric. Ubuntu
     # doesn't load .bashrc/.bash_profile for non-interactive shells.


### PR DESCRIPTION
btl_base_verbose output is set to 100 (debug) currently,
which dumps lots of output, especically for osu_mbw_mr,
and makes parsing log really hard.

Set it to 10 (component) instead for us to check the
test is using component tcp.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
