### PR TITLE
Modify Intel MPI procedures to fit the 2021 builds.

### DIFF
--- a/install-impi.sh
+++ b/install-impi.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-source ~/wget_check.sh
-wget_check "https://s3.us-west-2.amazonaws.com/subspace-intelmpi/l_mpi_2019.10.317.tgz" "l_mpi_2019.10.317.tgz"
-tar -zxf l_mpi_2019.10.317.tgz
-cd l_mpi_2019.10.317
-sed -e "s/decline/accept/" silent.cfg > accept.cfg
-sudo ./install.sh -s accept.cfg

--- a/mpi_common.sh
+++ b/mpi_common.sh
@@ -53,10 +53,11 @@ function ompi_setup {
 function impi_setup {
     LIBFABRIC_JOB_TYPE=$1
     if [ "$LIBFABRIC_JOB_TYPE" = "master" ]; then
-        source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh -ofi_internal=0
+        source /opt/intel/oneapi/mpi/latest/env/vars.sh -i_mpi_ofi_internal=0
         export LD_LIBRARY_PATH=${HOME}/libfabric/install/lib/:$LD_LIBRARY_PATH
     else
-        source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
+        # Use Intel MPI's internal libfabric (-i_mpi_ofi_internal=1 by default)
+        source /opt/intel/oneapi/mpi/latest/env/vars.sh
     fi
     export I_MPI_DEBUG=1
     export MPI_ARGS=""

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -153,7 +153,7 @@ test_list="impi"
 for mpi in $test_list; do
     execution_seq=$((${execution_seq}+1))
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-        bash mpi_ring_c_test.sh ${mpi} ${libfabric_job_type} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
+        bash mpi_ring_c_test.sh ${mpi} ${libfabric_job_type} ${PROVIDER} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
 
     set +e
     grep -q "Test Passed" ${output_dir}/temp_execute_ring_c_efa_minimal_${mpi}.txt
@@ -164,7 +164,7 @@ for mpi in $test_list; do
     set -e
 
     ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
-        bash mpi_osu_test.sh ${mpi} ${libfabric_job_type} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt
+        bash mpi_osu_test.sh ${mpi} ${libfabric_job_type} ${PROVIDER} ${INSTANCE_IPS[@]} | tee ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt
 
     set +e
     grep -q "Test Passed" ${output_dir}/temp_execute_osu_efa_minimal_${mpi}.txt

--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -18,7 +18,8 @@ ami=($slave_value)
 NODES=2
 export MINIMAL=1
 export RUN_IMPI_TESTS=1
-export LIBFABRIC_INSTALL_PATH=/opt/intel/impi/latest/libfabric/
+# Use Intel MPI's internal libfabric library.
+export LIBFABRIC_INSTALL_PATH=/opt/intel/oneapi/mpi/latest/libfabric/lib/
 
 
 # Current LibfabricCI IAM permissions do not allow placement group creation,


### PR DESCRIPTION
commit fb04f94075558064c8fb7692b379bd6ab71ade33 (HEAD -> impi2021, origin/impi2021)
Author: Shi Jin <sjina@amazon.com>
Date:   Wed Aug 4 11:57:11 2021 -0700

    Modify Intel MPI procedures to fit the 2021 builds.

    The current Intel MPI procedures are following the 2019 build's pattern.
    This patch modifies the usage of Intel MPI's env files and the location
    libfabric library path to fit the package layout of 2021 builds.

    Signed-off-by: Shi Jin <sjina@amazon.com>

commit c8684c22d7ee7ca57d653824a65dc6ba2e91c9a3
Author: Shi Jin <sjina@amazon.com>
Date:   Wed Aug 4 09:51:03 2021 -0700

    Remove the stale install-impi.sh script.

    Intel MPI is installed in the pre-built AMI that the test is running with,
    this script is not used during test and should be removed.

    Signed-off-by: Shi Jin <sjina@amazon.com>

commit bac08a9b86e23a0cdca3abc754e00a3066ce3891
Author: Shi Jin <sjina@amazon.com>
Date:   Thu Jul 8 13:27:26 2021 -0700

    Fix a bug in multi-node-efa-minimal.sh.

    In commit 8671dbf, the $PROVIDER variable is introduced as the third argument
    of mpi_ring_c_test.sh and mpi_osu_test.sh, to enable running MPI tests with
    different providers. However, this argument failed to be added to the corresponding
    scripts executions in minimal tests script.

    Signed-off-by: Shi Jin <sjina@amazon.com>