### PR TITLE
Adding cdi_test to libfabric-ci scripts

### DIFF
--- a/cdi_test/common/cdi-common.sh
+++ b/cdi_test/common/cdi-common.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+ami_arch="x86_64"
+label="alinux"
+SSH_USER="ec2-user"
+NODES=2
+PROVIDER="efa"
+ENABLE_PLACEMENT_GROUP=1
+
+create_cdi_test_user() {
+    POLICY_ARN=$(aws iam create-policy --policy-name ${POLICY_NAME} \
+                     --policy-document "file://${CDI_POLICY_DOCUMENT}" | jq -r '.Policy.Arn')
+    aws iam create-group --group-name ${GROUP_NAME}
+    aws iam create-user --user-name ${USER_NAME}
+    aws iam add-user-to-group --group-name ${GROUP_NAME} --user-name ${USER_NAME}
+    # Attach CloudWatchAgentServerPolicy
+    cloudwatchagentserverpolicy=$(aws iam list-policies --query 'Policies[?PolicyName==`CloudWatchAgentServerPolicy`].{ARN:Arn}' --output text)
+    aws iam attach-user-policy --user-name ${USER_NAME} --policy-arn ${cloudwatchagentserverpolicy}
+    aws iam attach-user-policy --user-name ${USER_NAME} --policy-arn ${POLICY_ARN}
+}
+
+delete_cdi_test_user() {
+    aws iam delete-access-key --access-key-id ${AWS_ACCESS_KEY_ID} --user-name ${USER_NAME}
+    aws iam detach-user-policy --user-name ${USER_NAME} --policy-arn ${cloudwatchagentserverpolicy}
+    aws iam detach-user-policy --user-name ${USER_NAME} --policy-arn ${POLICY_ARN}
+    aws iam remove-user-from-group --group-name ${GROUP_NAME} --user-name ${USER_NAME}
+    aws iam delete-policy --policy-arn ${POLICY_ARN}
+    aws iam delete-user --user-name ${USER_NAME}
+    aws iam delete-group --group-name ${GROUP_NAME}
+}

--- a/cdi_test/common/cdi-policy.json
+++ b/cdi_test/common/cdi-policy.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "mediaconnect:*",
+            "Resource": "*"
+        }
+    ]
+}

--- a/cdi_test/common/cdi-scripts.sh
+++ b/cdi_test/common/cdi-scripts.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+
+set -xe
+
+LIBFABRIC_BRANCH=${LIBFABRIC_BRANCH:-"main"}
+PULL_REQUEST_ID=${PULL_REQUEST_ID:-"None"}
+
+# cdi_test cmd file arguments
+declare -A CDI_TEST_ARGS=( [LOG_DIR]="${HOME}/cdi_test_logs" \
+                           [METRIC_NAME]="cdi_test_metric" \
+                           [PAYLOAD_SIZE]="24883200" \
+                           [LOCAL_IP]=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4) \
+                           [NUM_LOOPS]="1" )
+
+usage() {
+cat << EOF
+usage: $(basename "$0") [Options]
+
+Options:
+ [-c]           Command to run
+                    [configure_aws_iam_user, run_cdi_test_minimal,
+                    run_cdi_test, install_cdi_test]
+ [-t]           Connection type [tx|rx]
+ [-r]           Remote ip
+ [-n]           Number of full cdi-test loops to run (default: 1)
+ [-f]           The command file path for the full cdi-test
+ [-l]           Libfabric branch to install (default: main)
+ [-a]           AWS access key id
+ [-s]           AWS secret access key
+ [-u]           AWS IAM user use to post metrics
+ [-y]           Region to post metrics to
+ [-h]           Shows this help output
+EOF
+}
+
+while getopts c:t:r:n:f:l:a:s:u:h option; do
+case "${option}" in
+        c)
+            COMMAND=${OPTARG}
+            ;;
+        t)
+            CONNECTION_TYPE=${OPTARG}
+            ;;
+        r)
+            CDI_TEST_ARGS[REMOTE_IP]=${OPTARG}
+            ;;
+        n)
+            NUM_LOOPS=${OPTARG}
+            ;;
+        f)
+            COMMAND_FILE=${OPTARG}
+            ;;
+        l)
+            LIBFABRIC_BRANCH=${OPTARG}
+            ;;
+        a)
+            AWS_ACCESS_KEY_ID=${OPTARG}
+            ;;
+        s)
+            AWS_SECRET_ACCESS_KEY=${OPTARG}
+            ;;
+        u)
+            CDI_TEST_ARGS[CDI_TEST_IAM_USER]=${OPTARG}
+            ;;
+        y)
+            CDI_TEST_ARGS[REGION]=${OPTARG}
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# Cmake
+CMAKE_VERSION="3.15.3"
+CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}.tar.gz"
+
+# EFA Installer
+EFA_INSTALLER_VERSION="latest"
+EFA_INSTALLER_URL="https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz"
+
+# AWS cdi sdk
+AWS_CDI_SDK_URL="https://github.com/aws/aws-cdi-sdk"
+
+# Libfabric
+LIBFABRIC_URL="https://github.com/ofiwg/libfabric.git"
+
+# AWS sdk cpp
+AWS_SDK_CPP_BRANCH="1.8.46"
+AWS_SDK_CPP_URL="https://github.com/aws/aws-sdk-cpp.git"
+
+# name of the test directory to place cdi_test, libfabric, and aws sdk cpp
+CDI_TEST_DIR="${HOME}/cdi_test_dir/"
+CDI_TEST_BIN="${CDI_TEST_DIR}aws-cdi-sdk/build/debug/bin/"
+CDI_TEST_SRC="${CDI_TEST_BIN}cdi_test"
+CDI_TEST_MIN_RX_SRC="${CDI_TEST_BIN}cdi_test_min_rx"
+CDI_TEST_MIN_TX_SRC="${CDI_TEST_BIN}cdi_test_min_tx"
+
+# Configure aws iam user
+# This is needed to store metrics
+# Must specify:
+#   -c run_cdi_test
+#   -a <AWS_ACCESS_KEY_ID>
+#   -s <AWS_SECRET_ACCESS_KEY>
+configure_aws_iam_user() {
+    mkdir -p "${HOME}/.aws"
+
+    touch "${HOME}/.aws/credentials"
+    echo "[default]" >> ${HOME}/.aws/credentials
+    echo "aws_access_key_id=${AWS_ACCESS_KEY_ID}" >> ${HOME}/.aws/credentials
+    echo "aws_secret_access_key=${AWS_SECRET_ACCESS_KEY}" >> ${HOME}/.aws/credentials
+
+    touch ${HOME}/.aws/credentials
+}
+
+# Installs cdi_test dependencies
+install_cdi_test_deps() {
+    # Install Dependencies for cdi_test
+    sudo yum -y install gcc-c++ make libnl3-devel autoconf automake libtool doxygen ncurses-devel git
+    # Install Dependencies for sdk-cpp
+    sudo yum -y install libcurl-devel openssl-devel libuuid-devel pulseaudio-libs-devel
+}
+
+# Installs Cmake
+install_cmake() {
+    wget ${CMAKE_URL}
+    tar -zxvf "cmake-${CMAKE_VERSION}.tar.gz"
+    pushd "cmake-${CMAKE_VERSION}"
+    ./bootstrap --prefix=/usr/local
+    make
+    sudo make install
+    popd
+}
+
+# Installs minimal EFA drivers
+install_efa_minimal() {
+    curl -O ${EFA_INSTALLER_URL}
+    tar -xf "aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz"
+    pushd "aws-efa-installer"
+    sudo ./efa_installer.sh -y -m
+    popd
+}
+
+# Sets up CDI directory
+setup_cdi_test_directory() {
+    mkdir ${CDI_TEST_DIR}
+    mkdir ${CDI_TEST_ARGS[LOG_DIR]}
+    cd ${CDI_TEST_DIR}
+
+    git clone ${AWS_CDI_SDK_URL}
+    git clone ${LIBFABRIC_URL}
+    pushd libfabric
+    if [ ! "$PULL_REQUEST_ID" = "None" ]; then
+        git fetch origin +refs/pull/$PULL_REQUEST_ID/*:refs/remotes/origin/pr/$PULL_REQUEST_ID/*
+        git checkout $PULL_REQUEST_REF -b PRBranch
+    else
+        git checkout ${LIBFABRIC_BRANCH}
+    fi
+    popd
+    git clone -b ${AWS_SDK_CPP_BRANCH} ${AWS_SDK_CPP_URL}
+
+    # Build CDI libraries
+    cd aws-cdi-sdk/
+    make docs docs_api
+    make DEBUG=y AWS_SDK="${CDI_TEST_DIR}/aws-sdk-cpp/"
+}
+
+# Installs AWS CDI
+# Must specify:
+#   -c install_cdi_test
+install_cdi_test() {
+    install_cdi_test_deps
+    install_cmake
+    install_efa_minimal
+    setup_cdi_test_directory
+}
+
+# Runs the full cdi-test with the given command file
+# Must specify:
+#   -c run_cdi_test
+#   -t [rx|tx]
+#   -f <PATH_TO_COMMAND_FILE>
+#   -r <REMOTE_IP>
+#   -u <AWS_IAM_USER>
+#   -y <REGION>
+run_cdi_test() {
+    # Check that cmd_file exists
+    if [[ ! -f ${COMMAND_FILE} ]]; then
+        echo "cmd file does not exist: ${COMMAND_FILE}"
+        exit 1
+    fi
+
+    # Set the cdi_test arguments
+    if [[ ${CONNECTION_TYPE} == "rx" ]]; then
+        CDI_TEST_ARGS[RX_DEST_PORT]="2000"
+        CDI_TEST_ARGS[TX_DEST_PORT]="2100"
+    else
+        CDI_TEST_ARGS[TX_DEST_PORT]="2000"
+        CDI_TEST_ARGS[RX_DEST_PORT]="2100"
+    fi
+
+    # Replace arguments in cmd file
+    for args in "${!CDI_TEST_ARGS[@]}"; do
+        sed -i "s,<${args}>,${CDI_TEST_ARGS[$args]},g" ${COMMAND_FILE}
+    done
+
+    ${CDI_TEST_SRC} "@${COMMAND_FILE}"
+}
+
+# Run a minimal version of cdi_test for basic tx/rx communication
+# Must specify:
+#   -c run_cdi_test_minimal
+#   -t [rx|tx]
+# If connection-type == tx:
+#   -r <REMOTE_IP>
+run_cdi_test_minimal() {
+    if [[ ${CONNECTION_TYPE} == "rx" ]]; then
+        ${CDI_TEST_MIN_RX_SRC} --local_ip ${CDI_TEST_ARGS[LOCAL_IP]} \
+                               --rx RAW \
+                               --dest_port 2000 \
+                               --num_transactions 100 \
+                               --payload_size 5184000
+    else
+        ${CDI_TEST_MIN_TX_SRC} --local_ip ${CDI_TEST_ARGS[LOCAL_IP]} \
+                               --tx RAW \
+                               --remote_ip ${CDI_TEST_ARGS[REMOTE_IP]} \
+                               --dest_port 2000 \
+                               --rate 60 \
+                               --num_transactions 100 \
+                               --payload_size 5184000
+    fi
+}
+
+${COMMAND}

--- a/cdi_test/common/rxtx_cmd.txt
+++ b/cdi_test/common/rxtx_cmd.txt
@@ -1,0 +1,48 @@
+# change logs directory and prefix to whatever desired
+--logs <LOG_DIR>/rxtx
+--log_component "PROBE ENDPOINT_MANAGER PERFORMANCE_METRICS"
+
+# change local_ip to be for the efa being tested
+--local_ip <LOCAL_IP>
+--adapter EFA
+--stderr
+--num_loops <NUM_LOOPS>
+
+# change cloudwatch settings to whatever desired. The first is the metrics
+# name, the second is the AZ being published to, and the last is the user name.
+--stats_cloudwatch <METRIC NAME> <REGION> <CDI_TEST_IAM_USER>
+
+#---------------------------------------
+# rx connection 0
+-X
+# connection name is user specified
+--rx RAW
+--connection_name rx_fr_<LOCAL_IP>_<RX_DEST_PORT>
+--dest_port <RX_DEST_PORT>
+--core 5
+--rate 60
+--stats_period 10
+-S
+--pattern SHL
+--pat_start 1C014D6DA44CE61A
+--payload_size <PAYLOAD_SIZE>
+--num_transactions 0
+
+#---------------------------------------
+# tx connection 0
+-X
+--tx RAW
+--connection_name tx_to_<REMOTE_IP>_<TX_DEST_PORT>
+# change remote ip to efa on other instance
+--remote_ip <REMOTE_IP>
+--dest_port <TX_DEST_PORT>
+--tx_timeout 16666
+--keep_alive
+--core 6
+--rate 60
+--stats_period 10
+-S
+--pattern SHL
+--pat_start 1C014D6DA44CE61A
+--payload_size <PAYLOAD_SIZE>
+--num_transactions 0

--- a/cdi_test/tests/run-cdi.sh
+++ b/cdi_test/tests/run-cdi.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+
+set -xe
+REGION=${AWS_DEFAULT_REGION}
+
+RUN_MINIMAL=${RUN_MINIMAL:-0}
+RUN_FULL=${RUN_FULL:-0}
+
+CLIENT_LIBFABRIC_BRANCH=${CLIENT_LIBFABRIC_BRANCH:-"main"}
+SERVER_LIBFABRIC_BRANCH=${SERVER_LIBFABRIC_BRANCH:-"main"}
+
+PULL_REQUEST_ID=${PULL_REQUEST_ID:-"None"}
+
+CDI_COMMON="${WORKSPACE}/libfabric-ci-scripts/cdi_test/common"
+CDI_SCRIPT="${CDI_COMMON}/cdi-scripts.sh"
+CDI_CMD_FILE="${CDI_COMMON}/rxtx_cmd.txt"
+CDI_POLICY_DOCUMENT="${CDI_COMMON}/cdi-policy.json"
+
+echo "'INFO' ==> Starting perparation for cdi_test"
+source "${CDI_COMMON}/cdi-common.sh"
+source "${WORKSPACE}/libfabric-ci-scripts/common.sh"
+
+cdi_on_exit() {
+    delete_cdi_test_user
+    on_exit
+}
+
+cdi_execute_cmd() {
+    ip=$1
+    cmd=$2
+    ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        -o BatchMode=yes -o TCPKeepAlive=yes \
+        -i ~/${slave_keypair} ${SSH_USER}@${ip} ${cmd} --
+}
+
+trap 'cdi_on_exit'  EXIT
+
+echo "'INFO' ==> creating cdi_user ${BUILD_NUMBER} in iam"
+ROLE_NAME="cdi_role_${BUILD_NUMBER}"
+GROUP_NAME="cdi_group_${BUILD_NUMBER}"
+USER_NAME="cdi_user_${BUILD_NUMBER}"
+PROFILE_NAME="cdi_profile_${BUILD_NUMBER}"
+POLICY_NAME="cdi_policy_${BUILD_NUMBER}"
+create_cdi_test_user
+
+echo "'INFO' ==> creating access key for ${USER_NAME}"
+ACCESS_KEY_STRUCT=$(aws iam create-access-key --user-name ${USER_NAME})
+AWS_ACCESS_KEY_ID=$(echo ${ACCESS_KEY_STRUCT} | jq -r '.AccessKey.AccessKeyId')
+AWS_SECRET_ACCESS_KEY=$(echo ${ACCESS_KEY_STRUCT} | jq -r '.AccessKey.SecretAccessKey')
+
+# Launch instances
+echo "==> Creating Nodes"
+
+create_instance || { echo "==>Unable to create instance"; exit 65; }
+set -x
+INSTANCE_IDS=($INSTANCE_IDS)
+
+get_instance_ip
+INSTANCE_IPS=($INSTANCE_IPS)
+
+pids=""
+# Wait until all instances have passed SSH connection check
+for IP in ${INSTANCE_IPS[@]}; do
+    test_ssh "$IP" &
+    pids="$pids $!"
+done
+for pid in $pids; do
+    wait $pid || { echo "==>Instance ssh check failed"; exit 65; }
+done
+
+cdi_test_script="/home/${SSH_USER}/cdi-scripts.sh"
+
+# Put scripts on nodes
+for IP in ${INSTANCE_IPS[@]}; do
+    scp -i ~/${slave_keypair} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        ${CDI_SCRIPT} ${SSH_USER}@${IP}:/home/${SSH_USER}/
+
+    scp -i ~/${slave_keypair} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        ${CDI_CMD_FILE} ${SSH_USER}@${IP}:/home/${SSH_USER}/
+
+    cdi_execute_cmd ${IP} \
+    "${cdi_test_script} -c configure_aws_iam_user -a ${AWS_ACCESS_KEY_ID} -s ${AWS_SECRET_ACCESS_KEY}"
+done
+
+# Install cdi_test
+echo "==> Installing cdi_test on each node"
+
+set +e
+
+cdi_execute_cmd ${INSTANCE_IPS[0]} \
+    "export LIBFABRIC_BRANCH=${SERVER_LIBFABRIC_BRANCH}; \
+    export PULL_REQUEST_ID=${PULL_REQUEST_ID}; \
+    ${cdi_test_script} -c install_cdi_test" \
+    > server_install.out 2>&1 &
+
+server_pid=$!
+
+export LIBFABRIC_BRANCH=${CLIENT_LIBFABRIC_BRANCH}
+cdi_execute_cmd ${INSTANCE_IPS[1]} \
+    "export LIBFABRIC_BRANCH=${CLIENT_LIBFABRIC_BRANCH}; \
+    export PULL_REQUEST_ID=${PULL_REQUEST_ID}; \
+    ${cdi_test_script} -c install_cdi_test" \
+    > client_install.out 2>&1 &
+
+client_pid=$!
+
+wait ${server_pid}
+wait ${client_pid}
+if [[ $? -ne 0 ]]; then
+    echo "cdi_test installation failed."
+    exit 1
+fi
+
+set -e
+
+# Run cdi_test
+if [[ ${RUN_MINIMAL} -eq 1 ]]; then
+    set +e
+    echo "==> Running minimal cdi_test"
+
+    cdi_execute_cmd ${INSTANCE_IPS[0]} \
+        "${cdi_test_script} -c run_cdi_test_minimal -t rx" \
+        > server_minimal.out 2>&1 &
+
+    server_pid=$!
+
+    cdi_execute_cmd ${INSTANCE_IPS[1]} \
+        "${cdi_test_script} -c run_cdi_test_minimal -t tx -r ${INSTANCE_IPS[0]}" \
+        > client_minimal.out 2>&1 &
+
+    client_pid=$!
+
+    wait ${server_pid}
+    wait ${client_pid}
+    if [[ $? -ne 0 ]]; then
+        echo "Minimal cdi_test failed."
+    fi
+    set -e
+fi
+
+if [[ ${RUN_FULL} -eq 1 ]]; then
+    set +e
+    # run full cdi_test
+    echo "==> Running full cdi_test"
+
+    cdi_execute_cmd ${INSTANCE_IPS[0]} \
+              "${cdi_test_script} -c run_cdi_test -t rx -f /home/${SSH_USER}/rxtx_cmd.txt \
+              -r ${INSTANCE_IPS[1]} -u ${USER_NAME} -y ${REGION}" \
+              > server_full.out 2>&1 &
+
+    server_pid=$!
+
+    cdi_execute_cmd ${INSTANCE_IPS[1]}
+              "${cdi_test_script} -c run_cdi_test -t tx -f /home/${SSH_USER}/rxtx_cmd.txt \
+              -r ${INSTANCE_IPS[0]} -u ${USER_NAME} -y ${REGION}" \
+              > server_full.out 2>&1 &
+
+    client_pid=$!
+
+    wait ${server_pid}
+    wait ${client_pid}
+    if [[ $? -ne 0 ]]; then
+        echo "Full cdi_test failed."
+    fi
+    set -e
+fi
+
+echo "==> Test Passed"

--- a/common.sh
+++ b/common.sh
@@ -12,6 +12,7 @@ if [ ! "$ami_arch" = "x86_64" ] && [ ! "$ami_arch" = "aarch64" ]; then
     exit 1
 fi
 RUN_IMPI_TESTS=${RUN_IMPI_TESTS:-1}
+RUN_CDI_TESTS=${RUN_CDI_TESTS:-0}
 ENABLE_PLACEMENT_GROUP=${ENABLE_PLACEMENT_GROUP:-0}
 TEST_SKIP_KMOD=${TEST_SKIP_KMOD:-0}
 BUILD_GDR=${BUILD_GDR:-0}

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -182,4 +182,18 @@ if [ ${BUILD_GDR} -eq 1 ]; then
     fi
     set -e
 fi
+
+# Run cdi_test
+if [ ${RUN_CDI_TESTS} -eq 1 ]; then
+    set +e
+    export RUN_MINIMAL=1
+    bash $WORKSPACE/libfabric-ci-scripts/cdi_test/tests/run-cdi.sh | tee ${output_dir}/temp_execute_cdi_test.txt
+    grep -q "Test Passed" ${output_dir}/temp_execute_cdi_test.txt
+    if [ $? -ne 0 ]; then
+        BUILD_CODE=1
+        echo "cdi_test tests failed."
+    fi
+    set -e
+fi
+
 exit ${BUILD_CODE}


### PR DESCRIPTION
Added scripts and setup for running cdi_test. ./run-cdi.sh launches a client
and a server with cdi_test installed.

environment variables:
RUN_MINIMAL=1 runs minimal cdi_test tx/rx functionality
RUN_FULL=1 runs the full cdi_test. takes multiple days
tests backwards compatability between libfabric versions over minimal cdi_test suite
        |- CLIENT_LIBFABRIC_BRANCH sets the libfabric branch for the client
        |- SERVER_LIBFABRIC_BRANCH sets the libfabric branch for the server

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
