### PR TITLE
Add a test to explicitly test local read.

### DIFF
--- a/install-fabtests.sh
+++ b/install-fabtests.sh
@@ -22,9 +22,17 @@ if [ ! -z "${target_fabtest_tag}" ]; then
 fi
 cd ${HOME}/libfabric/fabtests
 ./autogen.sh
-./configure --with-libfabric=${LIBFABRIC_INSTALL_PATH} \
+configure_flags=(
+    --with-libfabric=${LIBFABRIC_INSTALL_PATH} \
     --prefix=${HOME}/libfabric/fabtests/install/ \
     --enable-debug
+    )
+# Build fabtests with cuda on x86_64 platform only.
+if [ "$(uname -m)" == "x86_64" ]; then
+    configure_flags+=(--with-cuda=/usr/local/cuda)
+fi
+
+./configure "${configure_flags[@]}"
 make -j 4
 make install
 

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -12,6 +12,8 @@ libfabric_job_type=${libfabric_job_type:-"master"}
 # enable this after it is fixed.
 # export ENABLE_PLACEMENT_GROUP=1
 export USER_DATA_FILE=${USER_DATA_FILE:-${JENKINS_HOME}/user_data_script.sh}
+# The tests running on GPUDirect instances will set this variable, other test stages will not.
+export BUILD_GDR=${BUILD_GDR:-0}
 
 # Test whether the instance is ready for SSH or not. Once the instance is ready,
 # copy SSH keys from Jenkins and install libfabric
@@ -42,7 +44,7 @@ execute_runfabtests()
     execution_seq=$((${execution_seq}+1))
     (ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS[0]} \
         "bash -s" -- < $WORKSPACE/libfabric-ci-scripts/multinode_runfabtests.sh \
-        "${PROVIDER}" "${INSTANCE_IPS[0]}" "${INSTANCE_IPS[$1]}" "${gid_c}" 2>&1; \
+        "${PROVIDER}" "${INSTANCE_IPS[0]}" "${INSTANCE_IPS[$1]}" "${gid_c}" "${BUILD_GDR}" 2>&1; \
         echo "EXIT_CODE=$?" > $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IPS[$1]}_execute_runfabtests.sh) | \
         tr \\r \\n | sed 's/\(.*\)/'${INSTANCE_IPS[0]}' \1/' | tee ${output_dir}/temp_execute_runfabtests.txt
     set -x

--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -4,14 +4,15 @@ run_test_with_expected_ret()
 {
     SERVER_IP=$1
     CLIENT_IP=$2
-    PROGRAM_TO_RUN=$3
-    EXPECT_RESULT=$4
+    SERVER_CMD=$3
+    CLIENT_CMD=$4
+    EXPECT_RESULT=$5
 
-    ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${SERVER_IP} ${PROGRAM_TO_RUN} >& server.out &
+    ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${SERVER_IP} ${SERVER_CMD} >& server.out &
     server_pid=$!
     sleep 1
 
-    ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${CLIENT_IP} ${PROGRAM_TO_RUN} ${SERVER_IP} >& client.out &
+    ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no ${CLIENT_IP} ${CLIENT_CMD} ${SERVER_IP} >& client.out &
     client_pid=$!
 
     wait $client_pid
@@ -106,26 +107,34 @@ if [ ${PROVIDER} == "efa" ]; then
 
     exit_code=0
     echo "Run fi_dgram_pingpong with out-of-band synchronization"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${HOME}/libfabric/fabtests/install/bin/fi_dgram_pingpong" "PASS"
+    SERVER_CMD="${HOME}/libfabric/fabtests/install/bin/fi_dgram_pingpong"
+    CLIENT_CMD="${SERVER_CMD}"
+    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
     if [ "$?" -ne 0 ]; then
         exit_code=1
     fi
 
     # Run fi_rdm_tagged_bw with fork when different environment variables are set.
     echo "Run fi_rdm_tagged_bw with fork"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -p efa -K -E" "FAIL"
+    SERVER_CMD="${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -p efa -K -E"
+    CLIENT_CMD="${SERVER_CMD}"
+    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "FAIL"
     if [ "$?" -ne 0 ]; then
         exit_code=1
     fi
 
     echo "Run fi_rdm_tagged_bw with fork and RDMAV_FORK_SAFE set"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "RDMAV_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E" "PASS"
+    SERVER_CMD="RDMAV_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E"
+    CLIENT_CMD="${SERVER_CMD}"
+    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
     if [ "$?" -ne 0 ]; then
         exit_code=1
     fi
 
     echo "Run fi_rdm_tagged_bw with fork and FI_EFA_FORK_SAFE set"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "FI_EFA_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E" "PASS"
+    SERVER_CMD="FI_EFA_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E"
+    CLIENT_CMD="${SERVER_CMD}"
+    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
     if [ "$?" -ne 0 ]; then
         exit_code=1
     fi

--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -55,6 +55,7 @@ set -xe
 PROVIDER=$1
 SERVER_IP=$2
 CLIENT_IP=$3
+BUILD_GDR=$5
 # Runs all the tests in the fabtests suite while only expanding failed cases
 EXCLUDE=${HOME}/libfabric/fabtests/install/share/fabtests/test_configs/${PROVIDER}/${PROVIDER}.exclude
 if [ -f ${EXCLUDE} ]; then
@@ -137,6 +138,16 @@ if [ ${PROVIDER} == "efa" ]; then
     run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
     if [ "$?" -ne 0 ]; then
         exit_code=1
+    fi
+
+    if [[ ${BUILD_GDR} -eq 1 ]]; then
+        echo "Run fi_rdm_tagged_bw with server using device (GPU) memory and client using host memory"
+        CLIENT_CMD="FI_EFA_USE_DEVICE_RDMA=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -p efa -E"
+        SERVER_CMD="${CLIENT_CMD} -D cuda"
+        run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
+        if [ "$?" -ne 0 ]; then
+            exit_code=1
+        fi
     fi
 
     if [ $restore_e -eq 1 ]; then


### PR DESCRIPTION
Local read is used when sender uses host memory and receiver uses GDR memory.
The current GDR tests does not cover this path. This PR added a test
on two GPUDirect RDMA instances (p4d) that run fi_rdm_tagged_bw with server
using device (CUDA) memory and client using host memory.