### PR TITLE
Temporarily exclude fi_rdm_multi_client on ARM

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -309,6 +309,8 @@ set_var()
     PULL_REQUEST_ID=$1
     PULL_REQUEST_REF=$2
     PROVIDER=$3
+    AMI_ARCH=$4
+    LIBFABRIC_JOB_TYPE=$5
     echo "==>Installing OS specific packages"
 EOF
 }

--- a/install-fabtests.sh
+++ b/install-fabtests.sh
@@ -45,6 +45,13 @@ if [ "${PROVIDER}" == "efa" ]; then
     echo "# skip dgram_pingpong test" >> ${EXCLUDE}
     echo "dgram_pingpong" >> ${EXCLUDE}
     echo "" >> ${EXCLUDE}
+
+    if [ "${AMI_ARCH}" == "aarch64" ] && [ ${LIBFABRIC_JOB_TYPE} == "master" ]; then
+        # temporarily exclude fi_rdm_multi_client test
+        echo "# skip rdm_multi_client test" >> ${EXCLUDE}
+        echo "rdm_multi_client" >> ${EXCLUDE}
+        echo "" >> ${EXCLUDE}
+    fi
 fi
 # .bashrc and .bash_profile are loaded differently depending on distro and
 # whether the shell is interactive or not, just do both to be safe.

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -24,7 +24,7 @@ install_libfabric()
     execution_seq=$((${execution_seq}+1))
     (ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@$1 \
         "bash -s" -- < ${tmp_script} \
-        "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" 2>&1; \
+        "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" "$ami_arch" "$libfabric_job_type" 2>&1; \
         echo "EXIT_CODE=$?" > $WORKSPACE/libfabric-ci-scripts/$1_install_libfabric.sh) \
         | tr \\r \\n | sed 's/\(.*\)/'$1' \1/' | tee ${output_dir}/${execution_seq}_$1_install_libfabric.txt
     set -x

--- a/single-node.sh
+++ b/single-node.sh
@@ -84,7 +84,7 @@ execution_seq=$((${execution_seq}+1))
 set +x
 ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@${INSTANCE_IPS} \
     "bash -s" -- <${tmp_script} \
-    "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" 2>&1 | tr \\r \\n | \
+    "$PULL_REQUEST_ID" "$PULL_REQUEST_REF" "$PROVIDER" "$ami_arch" "$libfabric_job_type" 2>&1 | tr \\r \\n | \
     sed 's/\(.*\)/'${INSTANCE_IPS}' \1/' | tee ${output_dir}/temp_execute_runfabtests.txt
 EXIT_CODE=${PIPESTATUS[0]}
 set -x


### PR DESCRIPTION
Temporarily exclude fi_rdm_multi_client on ARM
when using libfabric main branch

Signed-off-by: Jie Zhang <zhngaj@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
