### PR TITLE
Reduce the retry number and sleep time for create_instance function.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -73,6 +73,8 @@ delete_pg()
 # Launches EC2 instances.
 create_instance()
 {
+    local retry=10
+    local sleep_time=60
     # TODO: the labels need to be fixed in LibfabricCI and the stack
     # redeployed for PR testing
     # The ami-ids are stored in ssm paramater-store with names
@@ -167,7 +169,7 @@ create_instance()
     fi
 
     echo "==> Creating instances"
-    while [ ${error} -ne 0 ] && [ ${create_instance_count} -lt 30 ]; do
+    while [ ${error} -ne 0 ] && [ ${create_instance_count} -lt ${retry} ]; do
         for subnet in ${subnet_ids[@]}; do
             error=1
             set +e
@@ -208,7 +210,7 @@ create_instance()
                 exit 65
             fi
         done
-        sleep 2m
+        sleep ${sleep_time}
         create_instance_count=$((create_instance_count+1))
     done
 }


### PR DESCRIPTION
Currently, create_instance() retry 30 times to create instances, and
sleep 2 minutes between each retry. This could cost totally 2*30=60
minutes to create instances, which is too long. This patch reduces the
number of retry to 10 and the sleep time to 1 minutes. So the total
time cost of instance creation will not exceed 10 minutes.

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
