### PR TITLE
Fix issues when testing libfabric branches <=1.10.x

### DIFF
--- a/install-libfabric.sh
+++ b/install-libfabric.sh
@@ -20,7 +20,11 @@ configure_flags=(--prefix=${HOME}/libfabric/install/ \
     --enable-efa )
 # Build libfabric with cuda on x86_64 platform only.
 if [ "$(uname -m)" == "x86_64" ]; then
-    configure_flags+=(--with-cuda=/usr/local/cuda --enable-cuda-dlopen)
+    with_cuda_option_available="$(./configure -h 2>&1 | grep '\-\-with\-cuda' || true)"
+    enable_cuda_dlopen_option_available="$(./configure -h 2>&1 | grep '\-\-enable\-cuda\-dlopen' || true)"
+    if [[ -n "$with_cuda_option_available" && -n "$enable_cuda_dlopen_option_available" ]]; then
+        configure_flags+=(--with-cuda=/usr/local/cuda --enable-cuda-dlopen)
+    fi
 fi
 ./configure "${configure_flags[@]}"
 make -j 4

--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -116,28 +116,31 @@ if [ ${PROVIDER} == "efa" ]; then
     fi
 
     # Run fi_rdm_tagged_bw with fork when different environment variables are set.
-    echo "Run fi_rdm_tagged_bw with fork"
-    SERVER_CMD="${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -p efa -K -E"
-    CLIENT_CMD="${SERVER_CMD}"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "FAIL"
-    if [ "$?" -ne 0 ]; then
-        exit_code=1
-    fi
+    fork_option_available=$(${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -h 2>&1 | grep '\-K' || true)
+    if [ -n "$fork_option_available" ]; then
+        echo "Run fi_rdm_tagged_bw with fork"
+        SERVER_CMD="${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -p efa -K -E"
+        CLIENT_CMD="${SERVER_CMD}"
+        run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "FAIL"
+        if [ "$?" -ne 0 ]; then
+            exit_code=1
+        fi
 
-    echo "Run fi_rdm_tagged_bw with fork and RDMAV_FORK_SAFE set"
-    SERVER_CMD="RDMAV_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E"
-    CLIENT_CMD="${SERVER_CMD}"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
-    if [ "$?" -ne 0 ]; then
-        exit_code=1
-    fi
+        echo "Run fi_rdm_tagged_bw with fork and RDMAV_FORK_SAFE set"
+        SERVER_CMD="RDMAV_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E"
+        CLIENT_CMD="${SERVER_CMD}"
+        run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
+        if [ "$?" -ne 0 ]; then
+            exit_code=1
+        fi
 
-    echo "Run fi_rdm_tagged_bw with fork and FI_EFA_FORK_SAFE set"
-    SERVER_CMD="FI_EFA_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E"
-    CLIENT_CMD="${SERVER_CMD}"
-    run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
-    if [ "$?" -ne 0 ]; then
-        exit_code=1
+        echo "Run fi_rdm_tagged_bw with fork and FI_EFA_FORK_SAFE set"
+        SERVER_CMD="FI_EFA_FORK_SAFE=1 ${HOME}/libfabric/fabtests/install/bin/fi_rdm_tagged_bw -v -p efa -K -E"
+        CLIENT_CMD="${SERVER_CMD}"
+        run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
+        if [ "$?" -ne 0 ]; then
+            exit_code=1
+        fi
     fi
 
     if [[ ${BUILD_GDR} -eq 1 ]]; then


### PR DESCRIPTION
commit 18c0de80fc4daabf0d1a76aa719b29fb28beb2ce (HEAD -> fix_ci_errors, origin/fix_ci_errors)
Author: Shi Jin <sjina@amazon.com>
Date:   Wed Sep 1 19:59:05 2021 -0700

    Run fi_rdm_tagged_bw with "-K" when it's available.

    Currently, multinode_runfabtests.sh run fi_rdm_tagged_bw
    with -K for any efa tests. This is wrong because this fabtests
    option, and the efa fork support might be unavailable in older
    versions of libfabric. Add a conditional to check the availablity
    of this option before running the tests.

    Signed-off-by: Shi Jin <sjina@amazon.com>

commit d78e790e1e0db21ece45e36fcb3c5f604a6aa366
Author: Shi Jin <sjina@amazon.com>
Date:   Wed Sep 1 19:56:36 2021 -0700

    Use available configure options when building libfabric.

    Currently, install-libfabric.sh configures libfabric
    with "--with-cuda" and "--enable-cuda-dlopen" uniformly
    on x86 platforms. This is wrong because these two options
    are not available in some older versions of libfabric.
    Add conditionals to check the availabilities of these
    two options before adding them to the configure flags.

    Signed-off-by: Shi Jin <sjina@amazon.com>