### PR TITLE
Adding timeout to cdi_test

### DIFF
--- a/cdi_test/tests/run-cdi.sh
+++ b/cdi_test/tests/run-cdi.sh
@@ -24,6 +24,8 @@ NODES=2
 PROVIDER="efa"
 ENABLE_PLACEMENT_GROUP=1
 
+cdi_test_timeout=30m
+
 echo "'INFO' ==> Starting perparation for cdi_test"
 source "${WORKSPACE}/libfabric-ci-scripts/common.sh"
 
@@ -34,7 +36,7 @@ cdi_on_exit() {
 cdi_execute_cmd() {
     ip=$1
     cmd=$2
-    ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    timeout ${cdi_test_timeout} ssh -T -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
         -o BatchMode=yes -o TCPKeepAlive=yes \
         -i ~/${slave_keypair} ${SSH_USER}@${ip} ${cmd} --
 }


### PR DESCRIPTION
cdi_test is currently hanging with libfabric main branch. This prevents the
tests from hanging by introducing a timeout.

Signed-off-by: Nikola Dancejic <dancejic@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
