### PR TITLE
Do not explicitly define placement group in multi-node-efa-minimal.sh

### DIFF
--- a/multi-node-efa-minimal.sh
+++ b/multi-node-efa-minimal.sh
@@ -21,11 +21,6 @@ export RUN_IMPI_TESTS=1
 # Use Intel MPI's internal libfabric library.
 export LIBFABRIC_INSTALL_PATH=/opt/intel/oneapi/mpi/latest/libfabric/lib/
 
-
-# Current LibfabricCI IAM permissions do not allow placement group creation,
-# enable this after it is fixed.
-export ENABLE_PLACEMENT_GROUP=1
-
 efa_software_components_minimal()
 {
     if [ -z "$EFA_INSTALLER_URL" ]; then


### PR DESCRIPTION
This value may be already set from a calling script. Do not override
this value. In the case that this value is not set, common.sh will set
the value to 0.

Signed-off-by: William Zhang <wilzhang@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
