### PR TITLE
Check if GPUDirect RDMA is supported by reading from sysfs file

### DIFF
--- a/efa-check.sh
+++ b/efa-check.sh
@@ -118,13 +118,18 @@ if command -v ibv_devices >/dev/null 2>&1; then
     ibv_devices
 fi
 
+# check if GPUDirect RDMA is supported by
+# reading from sysfs file "/sys/class/infiniband/<device_name>/gdr"
 efa_gdr_enabled=0
-if sudo modinfo efa | grep gdr | grep -o Y; then
-    echo "EFA kmod has gdr enabled."
-    efa_gdr_enabled=1
-else
-    echo "EFA kmod does not have gdr enabled."
-fi
+for dev in /sys/class/infiniband/*/device; do
+    if [ "$(cat "${dev}"/gdr)" == "1" ]; then
+        echo "EFA GPUDirect RDMA support is enabled"
+        efa_gdr_enabled=1
+    else
+        echo "EFA GPUDirect RDMA support is not enabled"
+    fi
+done
+
 echo ""
 echo "======== Configuration check ========"
 # Check for memory lock limit and warn if less than 16GiB. 16GiB is enough for


### PR DESCRIPTION
Currently, the efa-check.sh check if GPUDirect RDMA is supported
    by checking if gdr: Y is present in efa's modinfo. This approach
    does not apply to the latest efa kernel driver (1.14.1) which combines
    the gdr/non-gdr packaging and has this line present in its modinfo always.
    The correct way to check if gdr is enabled is to read the value of sysfs file
    "/sys/class/infiniband/<device_name>/gdr", which should be 1 when p2pmem driver
    is available and 0 otherwise.