### PR TITLE
Add missing cmd options for multi-node fi_dgram_pingpong efa test.

### DIFF
--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -108,7 +108,7 @@ if [ ${PROVIDER} == "efa" ]; then
 
     exit_code=0
     echo "Run fi_dgram_pingpong with out-of-band synchronization"
-    SERVER_CMD="${HOME}/libfabric/fabtests/install/bin/fi_dgram_pingpong"
+    SERVER_CMD="${HOME}/libfabric/fabtests/install/bin/fi_dgram_pingpong -k -p efa -b"
     CLIENT_CMD="${SERVER_CMD}"
     run_test_with_expected_ret ${SERVER_IP} ${CLIENT_IP} "${SERVER_CMD}" "${CLIENT_CMD}" "PASS"
     if [ "$?" -ne 0 ]; then


### PR DESCRIPTION
fi_dgram_pingpong should be run with `-k -p efa -b` separately to
use out-of-band synchronization in commit 600ccb5, but this option
was removed incorrectly in commit 9d24015 as part of the code refactoring.
This patch adds the missing cmd options back.

Signed-off-by: Shi Jin <sjina@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
