### PR TITLE
use omb tarball in pre-built ami if available

### DIFF
--- a/mpi_osu_test.sh
+++ b/mpi_osu_test.sh
@@ -15,8 +15,14 @@ hosts=$@
 hostfile=$(mktemp)
 out=$(mktemp)
 
-wget_check "http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz" "osu-micro-benchmarks-5.6.2.tar.gz"
-osu_dir="osu-micro-benchmarks-5.6.2"
+if [ -f /softwares/osu-micro-benchmarks-5.6.tar.gz ]; then
+    cp /softwares/osu-micro-benchmarks-5.6.tar.gz .
+    osu_dir="osu-micro-benchmarks-5.6"
+else
+    wget_check "http://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.6.2.tar.gz" "osu-micro-benchmarks-5.6.2.tar.gz"
+    osu_dir="osu-micro-benchmarks-5.6.2"
+fi
+
 one_rank_per_node=""
 if [ "${mpi}" == "ompi" ]; then
     ompi_setup "${provider}"


### PR DESCRIPTION
Some pre-built ami has omb tarball, this patch uses it if
available.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
