### PR TITLE
Disable running fabtests with tcp provider on ARM instance 

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -112,20 +112,20 @@ if [ "${PROVIDER}" == "efa" ]; then
             exit 1
         fi
     done
+
+    execution_seq=$((${execution_seq}+1))
+    # SSH into SERVER node and run fabtests
+    N=$((${#INSTANCE_IPS[@]}-1))
+    for i in $(seq 1 $N); do
+        execute_runfabtests "$i"
+    done
+
+    # Get build status
+    for i in $(seq 1 $N); do
+        source $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IPS[$i]}_execute_runfabtests.sh
+        exit_status "$EXIT_CODE" "${INSTANCE_IPS[$i]}"
+    done
 fi
-
-execution_seq=$((${execution_seq}+1))
-# SSH into SERVER node and run fabtests
-N=$((${#INSTANCE_IPS[@]}-1))
-for i in $(seq 1 $N); do
-    execute_runfabtests "$i"
-done
-
-# Get build status
-for i in $(seq 1 $N); do
-    source $WORKSPACE/libfabric-ci-scripts/${INSTANCE_IPS[$i]}_execute_runfabtests.sh
-    exit_status "$EXIT_CODE" "${INSTANCE_IPS[$i]}"
-done
 
 # Run MPI tests for EFA provider.
 # For tests running on instances with ARM AMIs, also run MPI test if it's testing tcp.


### PR DESCRIPTION
EFA kernel module with ARM architecture is not shipped in the installer
for CentOS/RHEL 7. Currently, we are using a1.4xlarge instance and
running fabtests with libfabric tcp provider in centos7-arm and rhel7-arm
(Skip-Kmod test) in EFAInstallerProdCanary and LibfabricMainCanary.

However, we are seeing random failures with tcp provider, which causes
EFAInstallerProdCanary and LibfabricMainCanary jobs unstable. Therefore,
disable running fabtests with tcp provider in centos7-arm and rhel7-arm
skip-kmod test.

Signed-off-by: zhngaj <zhngaj@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
