### PR TITLE
Only disable running fabtests with tcp provider on ARM instance

### DIFF
--- a/multi-node.sh
+++ b/multi-node.sh
@@ -112,7 +112,10 @@ if [ "${PROVIDER}" == "efa" ]; then
             exit 1
         fi
     done
+fi
 
+# Only disable running fabtests with tcp provider on ARM instance
+if ! [[ "${PROVIDER}" == "tcp" && "$ami_arch" == "aarch64" ]]; then
     execution_seq=$((${execution_seq}+1))
     # SSH into SERVER node and run fabtests
     N=$((${#INSTANCE_IPS[@]}-1))


### PR DESCRIPTION
Last commit disables running fabtests with tcp provider on ARM instance
in centos7-arm and rhel7-arm in Canary tests.
But that change also excluded other provider on x86 arhitecture case,
which is the case on our PR test https://libfabric-ci.aws.a2z.com/job/multi-node
is using.

This patch fixed this issue, so PR test can also run fabtests
with other provider on x86 architecture.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>

Tested: 
PR multi-node test: http://libfabric-ci-392120037.us-west-2.elb.amazonaws.com/job/multi-node/PROVIDER=tcp,label=rhel/3/consoleFull
ProdCanaryTests: http://libfabric-ci-392120037.us-west-2.elb.amazonaws.com/blue/rest/organizations/jenkins/pipelines/EFAInstallerProdCanary/runs/16/nodes/49/steps/144/log/?start=0


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
