### PR TITLE
install-fabtests.sh: temporarily skipping checkout v1.16.x branch

### DIFF
--- a/install-fabtests.sh
+++ b/install-fabtests.sh
@@ -12,9 +12,11 @@ if [ ! -d libfabric ]; then
     # installed version of libfabric.
     git clone https://github.com/ofiwg/libfabric
     ofi_ver=$(${fi_info_bin} --version | grep 'libfabric api' | awk '{print $3}')
-    pushd libfabric
-    git checkout "v${ofi_ver}.x"
-    popd
+    if [ "${ofi_ver}" != "1.16" ]; then
+        pushd libfabric
+        git checkout "v${ofi_ver}.x"
+        popd
+    fi
 fi
 if [ ! -z "${target_fabtest_tag}" ]; then
     cd ${HOME}/libfabric


### PR DESCRIPTION
Some private installer will contain pre-release version of
libfabric 1.16. To test it, install-fabtests.sh will try
to checkout the v1.16.x branch. The v1.16.x branch does
not exist because libfabric 1.16 has not been released
yet.

Hence this patch skip checkout the branch if it is v1.16.x,
so test will proceed using main branch.

This patch will be reverted after release of libfabric
1.16.

Signed-off-by: Wei Zhang <wzam@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
