### PR TITLE
multinode_runfabtests.sh: Updated Kernel Space Support For Fork Check

### DIFF
--- a/fork_checker.c
+++ b/fork_checker.c
@@ -1,0 +1,16 @@
+#include <infiniband/verbs.h>
+#include <stdio.h>
+
+/*
+ * Check whether fork support is enabled on the instance by querying the rdma-core interface.
+ */
+int main()
+{
+	if (IBV_FORK_UNNEEDED != ibv_is_fork_initialized()) {
+		fprintf(stderr, "Kernel space fork support is not enabled \n");
+		return -1;
+	}
+
+	fprintf(stderr, "Kernel space fork support is enabled \n");
+	return 0;
+}

--- a/multi-node.sh
+++ b/multi-node.sh
@@ -23,6 +23,7 @@ install_libfabric()
     set +x
     scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair} ${ami[1]}@$1:~/.ssh/id_rsa
     scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/fabtests_${slave_keypair}.pub ${ami[1]}@$1:~/.ssh/id_rsa.pub
+    scp -o ConnectTimeout=30 -o StrictHostKeyChecking=no -i ~/${slave_keypair} $WORKSPACE/libfabric-ci-scripts/fork_checker.c ${ami[1]}@$1:~/fork_checker.c
     execution_seq=$((${execution_seq}+1))
     (ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=no -T -i ~/${slave_keypair} ${ami[1]}@$1 \
         "bash -s" -- < ${tmp_script} \

--- a/multinode_runfabtests.sh
+++ b/multinode_runfabtests.sh
@@ -2,26 +2,14 @@
 
 check_kernel_has_fork_support()
 {
-    host=$1
-    kernel_version=$(ssh $host uname -r)
-    older=$(printf "$kernel_version\n5.13.0" | sort -V | head -n 1)
-    if [ $older = "5.13.0" ]; then
+    gcc -I/usr/include -o ~/fork_checker ~/fork_checker.c -lefa -libverbs
+    ~/fork_checker
+
+    if [ 0 -eq $? ]; then
         return 1
-    else
-        # Rhel 8 now has fork support
-        release_name=$(ssh $host "cat /etc/os-release | grep '^NAME'")
-        os_name=$(echo $release_name | awk -F'=' ' gsub(/"/,"") {print $2}')
-        if [[ "$os_name" = "Red Hat Enterprise Linux" ]]; then
-            release_ver=$(ssh $host "cat /etc/os-release | grep '^VERSION_ID'")
-            rhel_ver=$(echo $release_ver | awk -F'=' ' gsub(/"/,"") {print $2}')
-            older=$(printf "$rhel_ver\n8.0" | sort -V | head -n 1)
-            if [ $older = "8.0" ]; then
-                # This version of rhel supports fork
-                return 1
-            fi
-        fi
-        return 0
     fi
+
+    return 0
 }
 
 run_test_with_expected_ret()


### PR DESCRIPTION
Switched existing check from looking at hardcoded OS versions to querying a kernel space function in rdma-core.

Signed-off-by: Seth Zegelstein <szegel@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
